### PR TITLE
feat: add hall of fame page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,10 +4,11 @@ import Header from './components/Header'
 import Footer from './components/Footer'
 import Home from './pages/Home'
 import Raffles from './pages/Raffles'
-  import RaffleDetails from './pages/RaffleDetails'
+import RaffleDetails from './pages/RaffleDetails'
 import Dashboard from './pages/Dashboard'
 import Auth from './pages/Auth'
-  import Admin from './pages/Admin'
+import Admin from './pages/Admin'
+import HallOfFame from './pages/HallOfFame'
 import { useAuth } from './context/AuthContext'
 
 function PrivateRoute({ children }) {
@@ -24,6 +25,7 @@ export default function App() {
           <Route path="/" element={<Home />} />
           <Route path="/raffles" element={<Raffles />} />
             <Route path="/raffles/:id" element={<RaffleDetails />} />
+          <Route path="/hall-of-fame" element={<HallOfFame />} />
           <Route path="/dashboard" element={<PrivateRoute><Dashboard /></PrivateRoute>} />
           <Route path="/auth" element={<Auth />} />
             <Route path="/admin" element={<Admin />} />

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -16,6 +16,7 @@ export default function Header() {
         <nav className="flex items-center gap-6 text-sm">
           <NavLink to="/" className={({isActive})=>isActive?'text-blue-light':'text-white/80 hover:text-white'}>Home</NavLink>
           <NavLink to="/raffles" className={({isActive})=>isActive?'text-blue-light':'text-white/80 hover:text-white'}>Raffles</NavLink>
+          <NavLink to="/hall-of-fame" className={({isActive})=>isActive?'text-blue-light':'text-white/80 hover:text-white'}>Hall of Fame</NavLink>
           {user && <NavLink to="/dashboard" className={({isActive})=>isActive?'text-blue-light':'text-white/80 hover:text-white'}>My Account</NavLink>}
             {user?.isAdmin && <NavLink to="/admin" className={({isActive})=>isActive?'text-blue-light':'text-white/80 hover:text-white'}>Admin</NavLink>}
         </nav>

--- a/src/pages/HallOfFame.jsx
+++ b/src/pages/HallOfFame.jsx
@@ -1,0 +1,114 @@
+import { useState, useMemo } from 'react'
+import { useAuth } from '../context/AuthContext'
+import { useRaffles } from '../context/RaffleContext'
+
+function maskUsername(name, currentUser) {
+  if (currentUser && currentUser.username === name) return name
+  return name.length <= 3 ? name : name.slice(0,3) + '***'
+}
+
+export default function HallOfFame() {
+  const { user, getAllUsers } = useAuth()
+  const { raffles } = useRaffles()
+  const [range, setRange] = useState('week') // 'week' or 'month'
+
+  const stats = useMemo(() => {
+    const days = range === 'week' ? 7 : 30
+    const cutoff = Date.now() - days * 24 * 60 * 60 * 1000
+
+    const tickets = {}
+    const wins = {}
+
+    raffles.forEach(r => {
+      if (r.endsAt >= cutoff) {
+        r.entries?.forEach(e => {
+          tickets[e.username] = (tickets[e.username] || 0) + e.count
+        })
+      }
+      if (r.ended && r.winner && r.endsAt >= cutoff) {
+        wins[r.winner] = (wins[r.winner] || 0) + 1
+      }
+    })
+
+    const users = getAllUsers()
+
+    const mostTickets = Object.entries(tickets)
+      .map(([username, value]) => ({ username, value }))
+      .sort((a,b) => b.value - a.value)
+      .slice(0,10)
+
+    const mostWins = Object.entries(wins)
+      .map(([username, value]) => ({ username, value }))
+      .sort((a,b) => b.value - a.value)
+      .slice(0,10)
+
+    const luckiest = users.map(u => {
+      const t = tickets[u.username] || 0
+      const w = wins[u.username] || 0
+      return { username: u.username, tickets: t, wins: w, value: t >= 5 ? w / t : 0 }
+    }).filter(x => x.tickets >= 5 && x.value > 0)
+      .sort((a,b) => b.value - a.value)
+      .slice(0,10)
+
+    return { mostTickets, mostWins, luckiest }
+  }, [range, raffles, getAllUsers])
+
+  const renderList = (list, formatter, maxValue) => {
+    if (!list.length) return <div className="text-center py-6 text-white/60">No data yet</div>
+    return (
+      <ul className="space-y-3">
+        {list.map((item, idx) => (
+          <li key={item.username}>
+            <div className="flex items-center gap-2">
+              <span className="w-5 text-sm">{idx + 1}.</span>
+              <span className="flex-1 text-sm">{maskUsername(item.username, user)}</span>
+              <span className="text-sm font-medium">{formatter(item)}</span>
+            </div>
+            <div className="h-1.5 bg-white/10 rounded-full overflow-hidden mt-1">
+              <div className="h-full bg-blue-light" style={{width: `${(item.value / (maxValue || 1)) * 100}%`}}></div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    )
+  }
+
+  return (
+    <div className="py-8">
+      <section className="min-h-[70vh] flex flex-col items-center justify-center text-center">
+        <h1 className="text-4xl md:text-6xl font-extrabold">Hall of Fame</h1>
+        <p className="text-white/70 mt-4 max-w-md">Celebrating our top raffle legends.</p>
+        <div className="mt-8 flex gap-3">
+          <button
+            onClick={() => setRange('week')}
+            className={`px-4 py-2 rounded-xl transition ${range==='week' ? 'bg-blue text-white' : 'bg-white/10 hover:bg-white/20'}`}
+          >
+            This Week
+          </button>
+          <button
+            onClick={() => setRange('month')}
+            className={`px-4 py-2 rounded-xl transition ${range==='month' ? 'bg-blue text-white' : 'bg-white/10 hover:bg-white/20'}`}
+          >
+            This Month
+          </button>
+        </div>
+      </section>
+
+      <section className="grid gap-6 md:grid-cols-3">
+        <div className="glass rounded-2xl p-6 border border-white/10 shadow-glow">
+          <h3 className="font-semibold mb-4">🎟️ Most Tickets Bought</h3>
+          {renderList(stats.mostTickets, i => i.value, stats.mostTickets[0]?.value)}
+        </div>
+        <div className="glass rounded-2xl p-6 border border-white/10 shadow-glow">
+          <h3 className="font-semibold mb-4">🏆 Most Wins</h3>
+          {renderList(stats.mostWins, i => i.value, stats.mostWins[0]?.value)}
+        </div>
+        <div className="glass rounded-2xl p-6 border border-white/10 shadow-glow">
+          <h3 className="font-semibold mb-4">🍀 Luckiest</h3>
+          {renderList(stats.luckiest, i => `${Math.round(i.value * 100)}%`, stats.luckiest[0]?.value)}
+        </div>
+      </section>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add Hall of Fame page with weekly/monthly leaderboards
- link Hall of Fame in navigation and routing

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: 403 Forbidden - GET https://registry.npmjs.org/vite)


------
https://chatgpt.com/codex/tasks/task_e_68c400d8e2fc83328c75b167709d909f