### PR TITLE
Add real-time activity ticker

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@
 import { Routes, Route, Navigate } from 'react-router-dom'
 import Header from './components/Header'
 import Footer from './components/Footer'
+import ActivityFeed from './components/ActivityFeed'
 import Home from './pages/Home'
 import Raffles from './pages/Raffles'
 import RaffleDetails from './pages/RaffleDetails'
@@ -33,6 +34,7 @@ export default function App() {
         </Routes>
       </main>
       <Footer />
+      <ActivityFeed />
     </div>
   )
 }

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -2,15 +2,14 @@
 import { useMemo, useState } from 'react'
 import { useAuth } from '../context/AuthContext'
 import { useRaffles } from '../context/RaffleContext'
-  import { useNotify } from '../context/NotificationContext'
-  import ActivityFeed from '../components/ActivityFeed'
+import { useNotify } from '../context/NotificationContext'
 
 export default function Dashboard() {
   const { getProfile, updateProfile } = useAuth()
   const { raffles } = useRaffles()
   const [amt, setAmt] = useState(10)
   const { notify, log } = useNotify()
-    const profile = getProfile()
+  const profile = getProfile()
 
   const myActive = useMemo(()=>{
     const ids = Object.keys(profile.entries || {}).map(n=>parseInt(n,10))


### PR DESCRIPTION
## Summary
- build animated ActivityFeed component that streams purchase and win events
- integrate ticker globally in App for a casino lobby feel
- tidy Dashboard imports

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: 403 Forbidden fetching vite)*

------
https://chatgpt.com/codex/tasks/task_e_68c404f497c88332a733c4de838cb728