### PR TITLE
feat: enhance Hall of Fame with seasonal leaderboards

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -23,11 +23,16 @@ export default {
           "0%": { transform: "translateY(0px)" },
           "50%": { transform: "translateY(-10px)" },
           "100%": { transform: "translateY(0px)" }
+        },
+        fadeInUp: {
+          "0%": { opacity: 0, transform: "translateY(8px)" },
+          "100%": { opacity: 1, transform: "translateY(0)" }
         }
       },
       animation: {
         gradient: "gradientMove 18s ease infinite",
-        floaty: "floaty 6s ease-in-out infinite"
+        floaty: "floaty 6s ease-in-out infinite",
+        "fade-in-up": "fadeInUp 0.4s ease forwards"
       },
       boxShadow: {
         glow: "0 0 30px rgba(127, 23, 52, 0.45)",


### PR DESCRIPTION
## Summary
- add seasonal week/month/all-time leaderboards with avatars and medals
- show champion banner and tooltip on luckiest ratio
- introduce fade-in-up animation in Tailwind config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vite)*

------
https://chatgpt.com/codex/tasks/task_e_68c4064ad4dc8332a17c1145490e28ff