### PR TITLE
feat: add dummy activity feed at top

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,7 @@ export default function App() {
   return (
     <div className="text-white min-h-screen flex flex-col">
       <Header />
+      <ActivityFeed />
       <main className="flex-1 px-4 md:px-8 max-w-7xl mx-auto w-full">
         <Routes>
           <Route path="/" element={<Home />} />
@@ -34,7 +35,6 @@ export default function App() {
         </Routes>
       </main>
       <Footer />
-      <ActivityFeed />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- generate random activity feed events every 5-10s
- position activity feed below the navbar

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: 403 Forbidden fetching vite)


------
https://chatgpt.com/codex/tasks/task_e_68c4095c15188332922433ba732c163d