### PR TITLE
feat: add demo chat dock

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import Admin from './pages/Admin'
 import HallOfFame from './pages/HallOfFame'
 import CommunityVote from './pages/CommunityVote'
 import { useAuth } from './context/AuthContext'
+import ChatDock from './components/chat/ChatDock'
 
 function PrivateRoute({ children }) {
   const { user } = useAuth()
@@ -36,6 +37,7 @@ export default function App() {
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </main>
+      <ChatDock />
       <Footer />
     </div>
   )

--- a/src/components/chat/ChatDock.jsx
+++ b/src/components/chat/ChatDock.jsx
@@ -1,0 +1,122 @@
+import { useEffect, useRef, useState } from 'react'
+import { useChat } from '../../context/ChatContext'
+import { useAuth } from '../../context/AuthContext'
+import Message from './Message'
+
+export default function ChatDock() {
+  const { rooms, messagesByRoom, activeRoomId, collapsed, unreadCounts, setCollapsed, setActiveRoom, sendMessage, createRoom } = useChat()
+  const { user } = useAuth()
+
+  const [guest, setGuest] = useState('')
+  useEffect(() => {
+    if (!user) {
+      let g = sessionStorage.getItem('rr_guest_id')
+      if (!g) {
+        g = 'guest-' + Math.floor(Math.random() * 9000 + 1000)
+        sessionStorage.setItem('rr_guest_id', g)
+      }
+      setGuest(g)
+    }
+  }, [user])
+
+  const username = user?.username || guest
+
+  const messages = messagesByRoom[activeRoomId] || []
+  const bottomRef = useRef(null)
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages.length, activeRoomId])
+
+  const [input, setInput] = useState('')
+  const handleSend = () => {
+    if (!input.trim()) return
+    sendMessage({ roomId: activeRoomId, author: username, text: input.trim() })
+    setInput('')
+  }
+  const handleKey = (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSend()
+    }
+  }
+
+  const totalUnread = Object.values(unreadCounts).reduce((a, b) => a + b, 0)
+
+  const [typing, setTyping] = useState(false)
+  const typingTimeout = useRef()
+  const handleFocus = () => {
+    setTyping(true)
+    clearTimeout(typingTimeout.current)
+    typingTimeout.current = setTimeout(() => setTyping(false), 2000)
+  }
+
+  const handleAddRoom = () => {
+    const name = prompt('New room name?')
+    if (name) createRoom(name)
+  }
+
+  if (collapsed) {
+    return (
+      <button
+        onClick={() => setCollapsed(false)}
+        className="fixed bottom-4 right-4 sm:right-4 sm:bottom-4 bg-black/30 border border-white/10 rounded-full px-4 py-2 shadow-glow flex items-center gap-2"
+      >
+        <span>Chat \uD83D\uDCAC</span>
+        {totalUnread > 0 && <span className="bg-red-500 text-white rounded-full px-2 text-xs">{totalUnread}</span>}
+      </button>
+    )
+  }
+
+  return (
+    <div className="fixed z-50 bottom-2 right-2 left-2 sm:left-auto sm:right-4 sm:bottom-4 w-auto sm:w-[360px] max-h-[70vh] bg-black/30 border border-white/10 rounded-2xl p-3 shadow-glow flex flex-col">
+      <div className="flex items-center gap-1 mb-2">
+        {rooms.map((r) => (
+          <button
+            key={r.id}
+            onClick={() => setActiveRoom(r.id)}
+            className={`px-3 py-1 rounded-xl text-sm ${r.id === activeRoomId ? 'bg-blue-light text-darker' : 'bg-white/10'}`}
+          >
+            {r.name}
+            {unreadCounts[r.id] > 0 && r.id !== activeRoomId && (
+              <span className="ml-1 text-xs">{unreadCounts[r.id]}</span>
+            )}
+          </button>
+        ))}
+        <button onClick={handleAddRoom} className="px-2 py-1 rounded-xl bg-white/10">+</button>
+        <button onClick={() => setCollapsed(true)} className="ml-auto px-2 py-1 rounded-xl bg-white/10">×</button>
+      </div>
+      <div className="flex-1 overflow-y-auto mb-2 space-y-1" role="log" aria-live="polite">
+        {messages.length === 0 && (
+          <div className="text-sm opacity-70 text-center mt-4">Say hi to start the conversation!</div>
+        )}
+        {messages.map((m) => (
+          <Message key={m.id} message={m} self={m.author === username} />
+        ))}
+        <div ref={bottomRef} />
+      </div>
+      {typing && (
+        <div className="text-xs italic mb-1 text-center">
+          <span className="animate-pulse mr-1">\u2022</span>Several users are typing…
+        </div>
+      )}
+      <div className="flex items-end gap-2">
+        <textarea
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKey}
+          onFocus={handleFocus}
+          rows={1}
+          className="flex-1 resize-none rounded-xl bg-black/30 border border-white/10 px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-light"
+        />
+        <button
+          onClick={handleSend}
+          className="px-3 py-2 rounded-xl bg-blue-light text-darker disabled:opacity-50"
+          disabled={!input.trim()}
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  )
+}
+

--- a/src/components/chat/Message.jsx
+++ b/src/components/chat/Message.jsx
@@ -1,0 +1,45 @@
+export function formatTime(ts) {
+  return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+}
+
+const COLORS = [
+  'bg-pink-500/30 text-pink-200',
+  'bg-blue-500/30 text-blue-200',
+  'bg-green-500/30 text-green-200',
+  'bg-yellow-500/30 text-yellow-200',
+  'bg-purple-500/30 text-purple-200',
+  'bg-red-500/30 text-red-200',
+  'bg-teal-500/30 text-teal-200',
+]
+
+export function colorFor(name) {
+  let hash = 0
+  for (const ch of name) hash = (hash + ch.charCodeAt(0)) % COLORS.length
+  return COLORS[hash]
+}
+
+export default function Message({ message, self }) {
+  const color = colorFor(message.author)
+  return (
+    <div className={`flex mb-2 ${self ? 'justify-end' : 'justify-start'}`}>
+      {!self && (
+        <div className={`w-8 h-8 rounded-full flex items-center justify-center mr-2 text-xs font-bold border border-white/10 ${color}`}>
+          {message.author[0].toUpperCase()}
+        </div>
+      )}
+      <div className={`max-w-[75%] rounded-xl px-3 py-1 bg-black/30 border border-white/10 ${self ? 'ml-auto text-right' : ''}`}>
+        <div className="text-[10px] opacity-70 flex justify-between gap-2">
+          <span>{message.author}</span>
+          <span>{formatTime(message.ts)}</span>
+        </div>
+        <div className="whitespace-pre-wrap break-words text-sm">{message.text}</div>
+      </div>
+      {self && (
+        <div className={`w-8 h-8 rounded-full flex items-center justify-center ml-2 text-xs font-bold border border-white/10 ${color}`}>
+          {message.author[0].toUpperCase()}
+        </div>
+      )}
+    </div>
+  )
+}
+

--- a/src/context/ChatContext.jsx
+++ b/src/context/ChatContext.jsx
@@ -1,0 +1,126 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+
+const ChatCtx = createContext(null)
+const STORAGE_KEY = 'rr_chat_state_v1'
+
+const DEFAULT_ROOMS = [
+  { id: 'lobby', name: 'Lobby' },
+  { id: 'giveaways', name: 'Giveaways' },
+  { id: 'winners', name: 'Winners' },
+]
+
+function seedMessages() {
+  const now = Date.now()
+  return {
+    lobby: [
+      { id: 'm1', author: 'alice', text: 'Anyone entering the iPhone raffle today?', ts: now - 1000 * 60 * 5 },
+      { id: 'm2', author: 'bob', text: 'Just grabbed 5 tickets 🎟️', ts: now - 1000 * 60 * 4 },
+    ],
+    giveaways: [
+      { id: 'm3', author: 'charlie', text: 'What\u2019s the next prize? PS5 or Cash?', ts: now - 1000 * 60 * 3 },
+      { id: 'm4', author: 'demo', text: 'Vote on the Community page!', ts: now - 1000 * 60 * 2 },
+    ],
+    winners: [
+      { id: 'm5', author: 'alice', text: 'GG to the PS5 winner last night \uD83C\uDF89', ts: now - 1000 * 60 },
+    ],
+  }
+}
+
+export function ChatProvider({ children }) {
+  const [state, setState] = useState(() => {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    return raw
+      ? JSON.parse(raw)
+      : {
+          rooms: [],
+          messagesByRoom: {},
+          activeRoomId: 'lobby',
+          collapsed: true,
+          unreadCounts: {},
+        }
+  })
+
+  const seedIfEmpty = () => {
+    setState((s) => {
+      if (s.rooms.length) return s
+      const messages = seedMessages()
+      const unread = {}
+      DEFAULT_ROOMS.forEach((r) => (unread[r.id] = 0))
+      return {
+        rooms: DEFAULT_ROOMS,
+        messagesByRoom: messages,
+        activeRoomId: 'lobby',
+        collapsed: true,
+        unreadCounts: unread,
+      }
+    })
+  }
+
+  useEffect(() => {
+    if (!state.rooms.length) seedIfEmpty()
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+  }, [state])
+
+  const setCollapsed = (v) => setState((s) => ({ ...s, collapsed: v }))
+
+  const setActiveRoom = (roomId) =>
+    setState((s) => ({
+      ...s,
+      activeRoomId: roomId,
+      unreadCounts: { ...s.unreadCounts, [roomId]: 0 },
+    }))
+
+  const sendMessage = ({ roomId, author, text }) =>
+    setState((s) => {
+      const msg = {
+        id: Math.random().toString(36).slice(2),
+        author,
+        text,
+        ts: Date.now(),
+      }
+      const messages = {
+        ...s.messagesByRoom,
+        [roomId]: [...(s.messagesByRoom[roomId] || []), msg],
+      }
+      const unread = { ...s.unreadCounts }
+      if (s.collapsed || s.activeRoomId !== roomId) {
+        unread[roomId] = (unread[roomId] || 0) + 1
+      }
+      return { ...s, messagesByRoom: messages, unreadCounts: unread }
+    })
+
+  const createRoom = (name) =>
+    setState((s) => {
+      const id = name.toLowerCase().replace(/\s+/g, '-')
+      if (s.rooms.find((r) => r.id === id)) return s
+      return {
+        ...s,
+        rooms: [...s.rooms, { id, name }],
+        messagesByRoom: { ...s.messagesByRoom, [id]: [] },
+        unreadCounts: { ...s.unreadCounts, [id]: 0 },
+      }
+    })
+
+  return (
+    <ChatCtx.Provider
+      value={{
+        ...state,
+        setCollapsed,
+        setActiveRoom,
+        sendMessage,
+        createRoom,
+        seedIfEmpty,
+      }}
+    >
+      {children}
+    </ChatCtx.Provider>
+  )
+}
+
+export function useChat() {
+  return useContext(ChatCtx)
+}
+

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -7,16 +7,19 @@ import './index.css'
 import { AuthProvider } from './context/AuthContext'
 import { RaffleProvider } from './context/RaffleContext'
   import { NotificationProvider } from './context/NotificationContext'
+import { ChatProvider } from './context/ChatContext'
 
 createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <BrowserRouter>
       <AuthProvider>
         <NotificationProvider>
-            <RaffleProvider>
-          <App />
-        </RaffleProvider>
-          </NotificationProvider>
+          <RaffleProvider>
+            <ChatProvider>
+              <App />
+            </ChatProvider>
+          </RaffleProvider>
+        </NotificationProvider>
       </AuthProvider>
     </BrowserRouter>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- add ChatContext with localStorage persistence and seeded demo rooms
- create ChatDock UI with room tabs, typing indicator, and message input
- wire chat provider and dock into app layout

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c40ed782408332bc184ed67bf0e05e