### PR TITLE
Refactor chat into sidebar and disable room creation

### DIFF
--- a/src/components/chat/ChatDock.jsx
+++ b/src/components/chat/ChatDock.jsx
@@ -4,7 +4,7 @@ import { useAuth } from '../../context/AuthContext'
 import Message from './Message'
 
 export default function ChatDock() {
-  const { rooms, messagesByRoom, activeRoomId, collapsed, unreadCounts, setCollapsed, setActiveRoom, sendMessage, createRoom } = useChat()
+  const { rooms, messagesByRoom, activeRoomId, collapsed, unreadCounts, setCollapsed, setActiveRoom, sendMessage } = useChat()
   const { user } = useAuth()
 
   const [guest, setGuest] = useState('')
@@ -50,11 +50,6 @@ export default function ChatDock() {
     typingTimeout.current = setTimeout(() => setTyping(false), 2000)
   }
 
-  const handleAddRoom = () => {
-    const name = prompt('New room name?')
-    if (name) createRoom(name)
-  }
-
   if (collapsed) {
     return (
       <button
@@ -68,7 +63,7 @@ export default function ChatDock() {
   }
 
   return (
-    <div className="fixed z-50 bottom-2 right-2 left-2 sm:left-auto sm:right-4 sm:bottom-4 w-auto sm:w-[360px] max-h-[70vh] bg-black/30 border border-white/10 rounded-2xl p-3 shadow-glow flex flex-col">
+    <div className="fixed z-50 inset-y-0 right-0 w-full sm:w-[360px] bg-black/30 border-l border-white/10 p-3 shadow-glow flex flex-col">
       <div className="flex items-center gap-1 mb-2">
         {rooms.map((r) => (
           <button
@@ -82,7 +77,6 @@ export default function ChatDock() {
             )}
           </button>
         ))}
-        <button onClick={handleAddRoom} className="px-2 py-1 rounded-xl bg-white/10">+</button>
         <button onClick={() => setCollapsed(true)} className="ml-auto px-2 py-1 rounded-xl bg-white/10">×</button>
       </div>
       <div className="flex-1 overflow-y-auto mb-2 space-y-1" role="log" aria-live="polite">

--- a/src/context/ChatContext.jsx
+++ b/src/context/ChatContext.jsx
@@ -35,7 +35,7 @@ export function ChatProvider({ children }) {
           rooms: [],
           messagesByRoom: {},
           activeRoomId: 'lobby',
-          collapsed: true,
+          collapsed: false,
           unreadCounts: {},
         }
   })
@@ -50,7 +50,7 @@ export function ChatProvider({ children }) {
         rooms: DEFAULT_ROOMS,
         messagesByRoom: messages,
         activeRoomId: 'lobby',
-        collapsed: true,
+        collapsed: false,
         unreadCounts: unread,
       }
     })
@@ -92,18 +92,6 @@ export function ChatProvider({ children }) {
       return { ...s, messagesByRoom: messages, unreadCounts: unread }
     })
 
-  const createRoom = (name) =>
-    setState((s) => {
-      const id = name.toLowerCase().replace(/\s+/g, '-')
-      if (s.rooms.find((r) => r.id === id)) return s
-      return {
-        ...s,
-        rooms: [...s.rooms, { id, name }],
-        messagesByRoom: { ...s.messagesByRoom, [id]: [] },
-        unreadCounts: { ...s.unreadCounts, [id]: 0 },
-      }
-    })
-
   return (
     <ChatCtx.Provider
       value={{
@@ -111,7 +99,6 @@ export function ChatProvider({ children }) {
         setCollapsed,
         setActiveRoom,
         sendMessage,
-        createRoom,
         seedIfEmpty,
       }}
     >


### PR DESCRIPTION
## Summary
- Show chat as a full-height sidebar instead of a floating dock
- Remove user ability to create new chat rooms
- Open chat by default so users collapse it only if desired

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vite)*

------
https://chatgpt.com/codex/tasks/task_e_68c41f6483c08332b7c250e29a399ef2