### PR TITLE
Make chat panel push content with solid background

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import HallOfFame from './pages/HallOfFame'
 import CommunityVote from './pages/CommunityVote'
 import { useAuth } from './context/AuthContext'
 import ChatDock from './components/chat/ChatDock'
+import { useChat } from './context/ChatContext'
 
 function PrivateRoute({ children }) {
   const { user } = useAuth()
@@ -20,8 +21,9 @@ function PrivateRoute({ children }) {
 }
 
 export default function App() {
+  const { collapsed } = useChat()
   return (
-    <div className="text-white min-h-screen flex flex-col">
+    <div className={`text-white min-h-screen flex flex-col transition-[padding] duration-300 ${collapsed ? '' : 'sm:pr-[360px]'}`}>
       <Header />
       <ActivityFeed />
       <main className="flex-1 px-4 md:px-8 max-w-7xl mx-auto w-full">

--- a/src/components/chat/ChatDock.jsx
+++ b/src/components/chat/ChatDock.jsx
@@ -54,7 +54,7 @@ export default function ChatDock() {
     return (
       <button
         onClick={() => setCollapsed(false)}
-        className="fixed bottom-4 right-4 sm:right-4 sm:bottom-4 bg-black/30 border border-white/10 rounded-full px-4 py-2 shadow-glow flex items-center gap-2"
+        className="fixed bottom-4 right-4 sm:right-4 sm:bottom-4 bg-darker border border-white/10 rounded-full px-4 py-2 shadow-glow flex items-center gap-2"
       >
         <span>Chat \uD83D\uDCAC</span>
         {totalUnread > 0 && <span className="bg-red-500 text-white rounded-full px-2 text-xs">{totalUnread}</span>}
@@ -63,7 +63,7 @@ export default function ChatDock() {
   }
 
   return (
-    <div className="fixed z-50 inset-y-0 right-0 w-full sm:w-[360px] bg-black/30 border-l border-white/10 p-3 shadow-glow flex flex-col">
+    <div className="fixed z-50 inset-y-0 right-0 w-full sm:w-[360px] bg-darker border-l border-white/10 p-3 shadow-glow flex flex-col">
       <div className="flex items-center gap-1 mb-2">
         {rooms.map((r) => (
           <button
@@ -100,7 +100,7 @@ export default function ChatDock() {
           onKeyDown={handleKey}
           onFocus={handleFocus}
           rows={1}
-          className="flex-1 resize-none rounded-xl bg-black/30 border border-white/10 px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-light"
+          className="flex-1 resize-none rounded-xl bg-darker border border-white/10 px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-light"
         />
         <button
           onClick={handleSend}


### PR DESCRIPTION
## Summary
- Shift page content left when chat is open so it's part of layout
- Give chat dock and button solid dark background instead of transparency

## Testing
- `npm test` (fails: Missing script)
- `npm run build` (fails: 403 Forbidden - GET https://registry.npmjs.org/vite)


------
https://chatgpt.com/codex/tasks/task_e_68c4214ba4a88332bfac1e70fdab4017