### PR TITLE
Fix register function uses defined user variable

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -67,10 +67,23 @@ export function AuthProvider({ children }) {
     if (users[username]) {
       return { ok: false, error: 'Username already exists' }
     }
-    users[username] = { username, password, balance: 100, entries: {}, wins: [], history: [], deposits: [], isAdmin:false }
+    const newUser = {
+      username,
+      password,
+      balance: 100,
+      entries: {},
+      wins: [],
+      history: [],
+      deposits: [],
+      isAdmin: false,
+    }
+    users[username] = newUser
     saveUsers(users)
-    sessionStorage.setItem('rr_user', JSON.stringify({ username, isAdmin: !!u.isAdmin }))
-    setUser({ username, isAdmin: !!u.isAdmin })
+    sessionStorage.setItem(
+      'rr_user',
+      JSON.stringify({ username, isAdmin: !!newUser.isAdmin })
+    )
+    setUser({ username, isAdmin: !!newUser.isAdmin })
     return { ok: true }
   }
 


### PR DESCRIPTION
## Summary
- Store new user in a variable before registering
- Use the defined user info when persisting session and state

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vite)*
- `node <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68c5aee527d883329c2b44702d6230a0