### PR TITLE
feat: add internationalization support

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.26.1",
+    "i18next": "^23.11.5",
+    "react-i18next": "^13.5.0",
 
     "vite": "^5.4.2",
     "@vitejs/plugin-react": "^4.3.1",

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,11 +1,13 @@
 
 import { Link, NavLink, useNavigate } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext'
+import { useTranslation } from 'react-i18next'
 
 export default function Header() {
   const { user, logout, getProfile } = useAuth()
   const nav = useNavigate()
   const balance = user ? getProfile()?.balance ?? 0 : 0
+  const { t, i18n } = useTranslation()
 
   return (
     <header className="sticky top-0 z-50 bg-black/30 backdrop-blur border-b border-white/10">
@@ -14,24 +16,32 @@ export default function Header() {
           <span className="text-claret">Royale</span><span className="text-blue-light">Raffles</span>
         </Link>
         <nav className="flex items-center gap-6 text-sm">
-          <NavLink to="/" className={({isActive})=>isActive?'text-blue-light':'text-white/80 hover:text-white'}>Home</NavLink>
-          <NavLink to="/raffles" className={({isActive})=>isActive?'text-blue-light':'text-white/80 hover:text-white'}>Raffles</NavLink>
-          <NavLink to="/community-vote" className={({isActive})=>isActive?'text-blue-light':'text-white/80 hover:text-white'}>Community Vote</NavLink>
-          <NavLink to="/hall-of-fame" className={({isActive})=>isActive?'text-blue-light':'text-white/80 hover:text-white'}>Hall of Fame</NavLink>
-          {user && <NavLink to="/dashboard" className={({isActive})=>isActive?'text-blue-light':'text-white/80 hover:text-white'}>My Account</NavLink>}
-            {user?.isAdmin && <NavLink to="/admin" className={({isActive})=>isActive?'text-blue-light':'text-white/80 hover:text-white'}>Admin</NavLink>}
+          <NavLink to="/" className={({isActive})=>isActive?'text-blue-light':'text-white/80 hover:text-white'}>{t('header.home')}</NavLink>
+          <NavLink to="/raffles" className={({isActive})=>isActive?'text-blue-light':'text-white/80 hover:text-white'}>{t('header.raffles')}</NavLink>
+          <NavLink to="/community-vote" className={({isActive})=>isActive?'text-blue-light':'text-white/80 hover:text-white'}>{t('header.community')}</NavLink>
+          <NavLink to="/hall-of-fame" className={({isActive})=>isActive?'text-blue-light':'text-white/80 hover:text-white'}>{t('header.hall')}</NavLink>
+          {user && <NavLink to="/dashboard" className={({isActive})=>isActive?'text-blue-light':'text-white/80 hover:text-white'}>{t('header.account')}</NavLink>}
+          {user?.isAdmin && <NavLink to="/admin" className={({isActive})=>isActive?'text-blue-light':'text-white/80 hover:text-white'}>{t('header.admin')}</NavLink>}
         </nav>
         <div className="flex items-center gap-3">
           {user ? (
             <>
-              <span className="text-white/80 text-sm hidden sm:block">Balance: <b className="text-blue-light">${balance.toFixed(2)}</b></span>
+              <span className="text-white/80 text-sm hidden sm:block">{t('header.balance')}: <b className="text-blue-light">${balance.toFixed(2)}</b></span>
               <button onClick={()=>{logout(); nav('/')}} className="px-3 py-1.5 rounded-xl bg-claret hover:bg-claret-light transition">
-                Logout
+                {t('header.logout')}
               </button>
             </>
           ) : (
-            <Link to="/auth" className="px-3 py-1.5 rounded-xl bg-blue hover:bg-blue-light transition">Login</Link>
+            <Link to="/auth" className="px-3 py-1.5 rounded-xl bg-blue hover:bg-blue-light transition">{t('header.login')}</Link>
           )}
+          <select
+            value={i18n.language}
+            onChange={(e)=>i18n.changeLanguage(e.target.value)}
+            className="bg-black/30 border border-white/10 rounded-xl px-2 py-1 text-sm"
+          >
+            <option value="en">EN</option>
+            <option value="es">ES</option>
+          </select>
         </div>
       </div>
     </header>

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,289 @@
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+
+const resources = {
+  en: {
+    translation: {
+      header: {
+        home: 'Home',
+        raffles: 'Raffles',
+        community: 'Community Vote',
+        hall: 'Hall of Fame',
+        account: 'My Account',
+        admin: 'Admin',
+        balance: 'Balance',
+        logout: 'Logout',
+        login: 'Login',
+        language: 'Language'
+      },
+      auth: {
+        login: 'Login',
+        register: 'Register',
+        demo: 'Use <b>demo/demo</b> to log in with a preloaded balance.',
+        username: 'Username',
+        password: 'Password',
+        createAccount: 'Create account',
+        needAccount: 'Need an account? Register',
+        haveAccount: 'Have an account? Login'
+      },
+      home: {
+        tagline: 'Play • Win • Repeat',
+        description: 'Enter raffles using your on-site balance, discover trending prizes, and track your wins — all in one playful, modern experience.',
+        browse: 'Browse Raffles',
+        login: 'Login / Register',
+        ticketsSold: 'Tickets sold:',
+        activeRaffles: 'Active raffles:',
+        winners: 'Winners:',
+        howItWorks: 'How it works',
+        step1: 'Top up your on-site balance.',
+        step2: 'Pick a raffle & choose your tickets.',
+        step3: 'Watch the countdown — winners are drawn fairly.',
+        maxPerUser: 'Max per user: <b>50%</b> of total tickets per raffle.',
+        secureTopups: 'Secure Top-Ups',
+        fairDraws: 'Fair Draws',
+        instantEntry: 'Instant Entry',
+        topRaffles: "This Week's Top Raffles",
+        trustSecure: 'Secure Top-Ups',
+        trustFair: 'Fair, random winners',
+        trustInstant: 'Instant ticket purchase'
+      },
+      raffles: {
+        search: 'Search raffles...',
+        all: 'All',
+        active: 'Active',
+        ended: 'Ended',
+        endingSoon: 'Ending Soon',
+        mostPopular: 'Most Popular',
+        prizeValue: 'Prize Value'
+      },
+      raffleDetails: {
+        notFound: 'Raffle not found',
+        notFoundDesc: "This raffle doesn't exist. Go back to the raffles list.",
+        estimated: 'Estimated value:',
+        ticketPrice: 'Ticket price:',
+        progress: 'Progress:',
+        timeLeft: 'Time left:',
+        yourTickets: 'Your tickets:',
+        maxPerUser: 'Max per user:',
+        back: 'Back',
+        enter: 'Enter Raffle',
+        participants: 'Participants',
+        recentEntries: 'Recent entries (anonymized):',
+        noEntries: 'No entries yet. Be the first!',
+        ended: 'Ended'
+      },
+      dashboard: {
+        myWallet: 'My Wallet',
+        currentBalance: 'Current Balance:',
+        topUp: 'Top up',
+        noDeposits: 'No deposits yet.',
+        activeEntries: 'Active Entries',
+        yourTickets: 'Your tickets:',
+        noActiveEntries: 'No active entries yet.',
+        endedRaffles: 'Ended Raffles',
+        winner: 'Winner:',
+        noEnded: 'No ended raffles yet.',
+        wins: 'Wins',
+        youWon: 'You won this raffle! 🎉',
+        noWins: 'No wins yet. Good luck!'
+      },
+      communityVote: {
+        title: 'Community Vote',
+        vote: 'Vote',
+        changeVote: 'Change vote',
+        pollEndsIn: 'Poll ends in',
+        votingClosed: 'Voting closed',
+        youVoted: 'You voted for {{option}}',
+        winner: 'Voting closed. Winner: {{option}}',
+        voteFor: 'Vote for {{option}}'
+      },
+      hallOfFame: {
+        title: 'Hall of Fame',
+        tagline: 'Celebrating our top raffle legends.',
+        currentWeek: 'Current Week',
+        currentMonth: 'Current Month',
+        allTime: 'All-Time',
+        noChampions: 'No champions yet... be the first!',
+        mostTickets: 'Most Tickets Bought',
+        mostWins: 'Most Wins',
+        luckiest: 'Luckiest',
+        championMostTickets: 'Most Tickets',
+        championMostWins: 'Most Wins',
+        championLuckiest: 'Luckiest'
+      },
+      admin: {
+        raffles: 'Raffles',
+        users: 'Users',
+        analytics: 'Analytics',
+        manageRaffles: 'Manage Raffles',
+        newRaffle: '+ New Raffle',
+        edit: 'Edit',
+        endNow: 'End Now',
+        ended: 'Ended',
+        editRaffle: 'Edit Raffle',
+        newRaffleTitle: 'New Raffle',
+        title: 'Title',
+        imageUrl: 'Image URL',
+        description: 'Description',
+        value: 'Value',
+        ticketPrice: 'Ticket Price',
+        totalTickets: 'Total Tickets',
+        category: 'Category',
+        cancel: 'Cancel',
+        save: 'Save',
+        username: 'Username',
+        balance: 'Balance',
+        admin: 'Admin',
+        yes: 'Yes',
+        no: 'No'
+      }
+    }
+  },
+  es: {
+    translation: {
+      header: {
+        home: 'Inicio',
+        raffles: 'Rifas',
+        community: 'Votación comunitaria',
+        hall: 'Salón de la Fama',
+        account: 'Mi cuenta',
+        admin: 'Admin',
+        balance: 'Balance',
+        logout: 'Cerrar sesión',
+        login: 'Iniciar sesión',
+        language: 'Idioma'
+      },
+      auth: {
+        login: 'Iniciar sesión',
+        register: 'Registrarse',
+        demo: 'Usa <b>demo/demo</b> para iniciar con saldo precargado.',
+        username: 'Usuario',
+        password: 'Contraseña',
+        createAccount: 'Crear cuenta',
+        needAccount: '¿Necesitas una cuenta? Regístrate',
+        haveAccount: '¿Tienes una cuenta? Inicia sesión'
+      },
+      home: {
+        tagline: 'Juega • Gana • Repite',
+        description: 'Entra a rifas con tu saldo, descubre premios de moda y sigue tus victorias — todo en una experiencia moderna.',
+        browse: 'Ver Rifas',
+        login: 'Iniciar / Registrar',
+        ticketsSold: 'Boletos vendidos:',
+        activeRaffles: 'Rifas activas:',
+        winners: 'Ganadores:',
+        howItWorks: 'Cómo funciona',
+        step1: 'Recarga tu saldo en el sitio.',
+        step2: 'Elige una rifa y compra boletos.',
+        step3: 'Mira la cuenta regresiva — los ganadores se eligen justamente.',
+        maxPerUser: 'Máximo por usuario: <b>50%</b> de los boletos totales por rifa.',
+        secureTopups: 'Recargas seguras',
+        fairDraws: 'Sorteos justos',
+        instantEntry: 'Entrada instantánea',
+        topRaffles: 'Las mejores rifas de esta semana',
+        trustSecure: 'Recargas seguras',
+        trustFair: 'Ganadores justos y aleatorios',
+        trustInstant: 'Compra de boletos instantánea'
+      },
+      raffles: {
+        search: 'Buscar rifas...',
+        all: 'Todas',
+        active: 'Activas',
+        ended: 'Finalizadas',
+        endingSoon: 'Termina pronto',
+        mostPopular: 'Más populares',
+        prizeValue: 'Valor del premio'
+      },
+      raffleDetails: {
+        notFound: 'Rifa no encontrada',
+        notFoundDesc: 'Esta rifa no existe. Regresa a la lista de rifas.',
+        estimated: 'Valor estimado:',
+        ticketPrice: 'Precio del boleto:',
+        progress: 'Progreso:',
+        timeLeft: 'Tiempo restante:',
+        yourTickets: 'Tus boletos:',
+        maxPerUser: 'Máx por usuario:',
+        back: 'Volver',
+        enter: 'Entrar a la rifa',
+        participants: 'Participantes',
+        recentEntries: 'Entradas recientes (anonimizadas):',
+        noEntries: 'Sin entradas aún. ¡Sé el primero!',
+        ended: 'Finalizada'
+      },
+      dashboard: {
+        myWallet: 'Mi Billetera',
+        currentBalance: 'Saldo actual:',
+        topUp: 'Recargar',
+        noDeposits: 'Sin depósitos aún.',
+        activeEntries: 'Entradas activas',
+        yourTickets: 'Tus boletos:',
+        noActiveEntries: 'Sin entradas activas.',
+        endedRaffles: 'Rifas finalizadas',
+        winner: 'Ganador:',
+        noEnded: 'Sin rifas finalizadas.',
+        wins: 'Ganadas',
+        youWon: '¡Ganaste esta rifa! 🎉',
+        noWins: 'Aún sin victorias. ¡Suerte!'
+      },
+      communityVote: {
+        title: 'Votación comunitaria',
+        vote: 'Votar',
+        changeVote: 'Cambiar voto',
+        pollEndsIn: 'La encuesta termina en',
+        votingClosed: 'Votación cerrada',
+        youVoted: 'Votaste por {{option}}',
+        winner: 'Votación cerrada. Ganador: {{option}}',
+        voteFor: 'Votar por {{option}}'
+      },
+      hallOfFame: {
+        title: 'Salón de la Fama',
+        tagline: 'Celebrando a nuestros mejores concursantes.',
+        currentWeek: 'Semana actual',
+        currentMonth: 'Mes actual',
+        allTime: 'Histórico',
+        noChampions: 'Sin campeones aún... ¡sé el primero!',
+        mostTickets: 'Más boletos comprados',
+        mostWins: 'Más victorias',
+        luckiest: 'Más suertudos',
+        championMostTickets: 'Más boletos',
+        championMostWins: 'Más victorias',
+        championLuckiest: 'Más suertudo'
+      },
+      admin: {
+        raffles: 'Rifas',
+        users: 'Usuarios',
+        analytics: 'Analítica',
+        manageRaffles: 'Administrar rifas',
+        newRaffle: '+ Nueva rifa',
+        edit: 'Editar',
+        endNow: 'Terminar ahora',
+        ended: 'Finalizada',
+        editRaffle: 'Editar rifa',
+        newRaffleTitle: 'Nueva rifa',
+        title: 'Título',
+        imageUrl: 'URL de imagen',
+        description: 'Descripción',
+        value: 'Valor',
+        ticketPrice: 'Precio del boleto',
+        totalTickets: 'Boletos totales',
+        category: 'Categoría',
+        cancel: 'Cancelar',
+        save: 'Guardar',
+        username: 'Usuario',
+        balance: 'Saldo',
+        admin: 'Admin',
+        yes: 'Sí',
+        no: 'No'
+      }
+    }
+  }
+}
+
+i18n.use(initReactI18next).init({
+  resources,
+  lng: 'en',
+  fallbackLng: 'en',
+  interpolation: { escapeValue: false }
+})
+
+export default i18n
+

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,25 +2,29 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
+import { I18nextProvider } from 'react-i18next'
+import i18n from './i18n'
 import App from './App'
 import './index.css'
 import { AuthProvider } from './context/AuthContext'
 import { RaffleProvider } from './context/RaffleContext'
-  import { NotificationProvider } from './context/NotificationContext'
+import { NotificationProvider } from './context/NotificationContext'
 import { ChatProvider } from './context/ChatContext'
 
 createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <AuthProvider>
-        <NotificationProvider>
-          <RaffleProvider>
-            <ChatProvider>
-              <App />
-            </ChatProvider>
-          </RaffleProvider>
-        </NotificationProvider>
-      </AuthProvider>
-    </BrowserRouter>
+    <I18nextProvider i18n={i18n}>
+      <BrowserRouter>
+        <AuthProvider>
+          <NotificationProvider>
+            <RaffleProvider>
+              <ChatProvider>
+                <App />
+              </ChatProvider>
+            </RaffleProvider>
+          </NotificationProvider>
+        </AuthProvider>
+      </BrowserRouter>
+    </I18nextProvider>
   </React.StrictMode>
 )

--- a/src/pages/Auth.jsx
+++ b/src/pages/Auth.jsx
@@ -2,6 +2,7 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext'
+import { useTranslation } from 'react-i18next'
 
 export default function Auth() {
   const [mode, setMode] = useState('login')
@@ -10,6 +11,7 @@ export default function Auth() {
   const [error, setError] = useState('')
   const { login, register } = useAuth()
   const nav = useNavigate()
+  const { t } = useTranslation()
 
   const handle = () => {
     if (mode === 'login') {
@@ -26,17 +28,17 @@ export default function Auth() {
   return (
     <div className="py-10 flex items-center justify-center">
       <div className="glass rounded-3xl p-8 w-full max-w-md">
-        <h2 className="text-2xl font-bold">{mode==='login'?'Login':'Register'}</h2>
-        <p className="text-white/70 text-sm mt-1">Use <b>demo/demo</b> to log in with a preloaded balance.</p>
+        <h2 className="text-2xl font-bold">{mode==='login'?t('auth.login'):t('auth.register')}</h2>
+        <p className="text-white/70 text-sm mt-1" dangerouslySetInnerHTML={{ __html: t('auth.demo') }} />
         <div className="space-y-3 mt-6">
-          <input placeholder="Username" value={username} onChange={e=>setUsername(e.target.value)}
+          <input placeholder={t('auth.username')} value={username} onChange={e=>setUsername(e.target.value)}
             className="w-full bg-black/30 border border-white/10 rounded-xl px-3 py-2 outline-none" />
-          <input placeholder="Password" type="password" value={password} onChange={e=>setPassword(e.target.value)}
+          <input placeholder={t('auth.password')} type="password" value={password} onChange={e=>setPassword(e.target.value)}
             className="w-full bg-black/30 border border-white/10 rounded-xl px-3 py-2 outline-none" />
           {error && <div className="text-sm text-red-400">{error}</div>}
-          <button onClick={handle} className="w-full px-4 py-2 rounded-2xl bg-blue hover:bg-blue-light">{mode==='login'?'Login':'Create account'}</button>
+          <button onClick={handle} className="w-full px-4 py-2 rounded-2xl bg-blue hover:bg-blue-light">{mode==='login'?t('auth.login'):t('auth.createAccount')}</button>
           <button onClick={()=>{setMode(mode==='login'?'register':'login'); setError('')}} className="w-full px-4 py-2 rounded-2xl bg-white/10 hover:bg-white/20">
-            {mode==='login'?'Need an account? Register':'Have an account? Login'}
+            {mode==='login'?t('auth.needAccount'):t('auth.haveAccount')}
           </button>
         </div>
       </div>

--- a/src/pages/CommunityVote.jsx
+++ b/src/pages/CommunityVote.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useAuth } from '../context/AuthContext'
 import { useNotify } from '../context/NotificationContext'
+import { useTranslation } from 'react-i18next'
 
 // Lightweight confetti helper using emoji burst
 function confetti() {
@@ -42,6 +43,7 @@ function Countdown({ endsAt, onEnd }) {
 }
 
 function OptionCard({ option, selected, onVote, disabled }) {
+  const { t } = useTranslation()
   return (
     <div className="glass rounded-2xl p-4 flex flex-col items-center text-center space-y-3 relative">
       {option.image ? (
@@ -53,14 +55,14 @@ function OptionCard({ option, selected, onVote, disabled }) {
       <button
         onClick={() => onVote(option.id)}
         disabled={disabled}
-        aria-label={`Vote for ${option.label}`}
+        aria-label={t('communityVote.voteFor', { option: option.label })}
         className={
           'px-4 py-1.5 rounded-xl transition ' +
           (selected ? 'bg-claret hover:bg-claret-light' : 'bg-blue hover:bg-blue-light') +
           (disabled ? ' opacity-50 cursor-not-allowed' : '')
         }
       >
-        {selected ? 'Change vote' : 'Vote'}
+        {selected ? t('communityVote.changeVote') : t('communityVote.vote')}
       </button>
     </div>
   )
@@ -100,6 +102,7 @@ function Results({ options, tallies, totalVotes, winningOptionId, closed }) {
 export default function CommunityVote() {
   const { user } = useAuth()
   const { notify, log } = useNotify()
+  const { t } = useTranslation()
 
   const poll = {
     id: 'poll_001',
@@ -165,7 +168,7 @@ export default function CommunityVote() {
       localStorage.setItem(storageKey, JSON.stringify(next))
       return next
     })
-    notify(`You voted for ${optionLabel}`)
+    notify(t('communityVote.youVoted', { option: optionLabel }))
     log({ type: 'vote', pollId: poll.id, voter: voterId, option: optionId })
   }
 
@@ -180,21 +183,21 @@ export default function CommunityVote() {
     confetti()
     log({ type: 'poll-ended', pollId: poll.id, winner: win })
     const label = poll.options.find((o) => o.id === win)?.label
-    notify(`Voting closed. Winner: ${label}`)
+    notify(t('communityVote.winner', { option: label }))
   }
 
   return (
     <div className="py-8">
       {/* HERO */}
       <section className="min-h-[70vh] flex flex-col items-center justify-center text-center space-y-4">
-        <h1 className="text-4xl md:text-5xl font-extrabold">Community Vote</h1>
+        <h1 className="text-4xl md:text-5xl font-extrabold">{t('communityVote.title')}</h1>
         <p className="text-white/70 max-w-xl">{poll.title}</p>
         {!closed ? (
           <div className="text-xl">
-            Poll ends in <Countdown endsAt={poll.endsAt} onEnd={handleEnd} />
+            {t('communityVote.pollEndsIn')} <Countdown endsAt={poll.endsAt} onEnd={handleEnd} />
           </div>
         ) : (
-          <div className="text-xl">Voting closed</div>
+          <div className="text-xl">{t('communityVote.votingClosed')}</div>
         )}
       </section>
 

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -4,6 +4,7 @@ import { useAuth } from '../context/AuthContext'
 import { useRaffles } from '../context/RaffleContext'
 import { useNotify } from '../context/NotificationContext'
 import DepositModal from '../components/DepositModal'
+import { useTranslation } from 'react-i18next'
 
 export default function Dashboard() {
   const { getProfile, updateProfile } = useAuth()
@@ -12,6 +13,7 @@ export default function Dashboard() {
   const [showDeposit, setShowDeposit] = useState(false)
   const { notify, log } = useNotify()
   const profile = getProfile()
+  const { t } = useTranslation()
 
   const myActive = useMemo(()=>{
     const ids = Object.keys(profile.entries || {}).map(n=>parseInt(n,10))
@@ -46,11 +48,11 @@ export default function Dashboard() {
   return (
     <div className="py-8 space-y-8">
       <section className="glass rounded-2xl p-6">
-        <h2 className="text-2xl font-bold">My Wallet</h2>
-        <div className="mt-2 text-white/80">Current Balance: <b className="text-blue-light">${profile.balance.toFixed(2)}</b></div>
+        <h2 className="text-2xl font-bold">{t('dashboard.myWallet')}</h2>
+        <div className="mt-2 text-white/80">{t('dashboard.currentBalance')} <b className="text-blue-light">${profile.balance.toFixed(2)}</b></div>
         <div className="mt-3 flex items-center gap-2">
           <input type="number" min="1" value={amt} onChange={e=>setAmt(e.target.value)} className="bg-black/30 border border-white/10 rounded-xl px-3 py-2"/>
-          <button onClick={openDeposit} className="px-4 py-2 rounded-xl bg-blue hover:bg-blue-light">Top up</button>
+          <button onClick={openDeposit} className="px-4 py-2 rounded-xl bg-blue hover:bg-blue-light">{t('dashboard.topUp')}</button>
         </div>
         <div className="mt-4 space-y-1 text-sm text-white/70">
           {(profile.deposits || []).map(d => (
@@ -59,12 +61,12 @@ export default function Dashboard() {
               <span className="text-blue-light">${d.amount.toFixed(2)}</span>
             </div>
           ))}
-          {(!profile.deposits || profile.deposits.length === 0) && <div className="text-white/60">No deposits yet.</div>}
+          {(!profile.deposits || profile.deposits.length === 0) && <div className="text-white/60">{t('dashboard.noDeposits')}</div>}
         </div>
       </section>
 
       <section className="glass rounded-2xl p-6">
-        <h3 className="text-xl font-semibold">Active Entries</h3>
+        <h3 className="text-xl font-semibold">{t('dashboard.activeEntries')}</h3>
         <div className="mt-4 grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {myActive.map(r => (
             <div key={r.id} className="p-4 border border-white/10 rounded-xl bg-black/20">
@@ -72,39 +74,39 @@ export default function Dashboard() {
                 <img src={r.image} className="w-16 h-16 object-cover rounded-lg" />
                 <div>
                   <div className="font-semibold">{r.title}</div>
-                  <div className="text-sm text-white/70">Your tickets: <b>{profile.entries[r.id]}</b></div>
+                  <div className="text-sm text-white/70">{t('dashboard.yourTickets')} <b>{profile.entries[r.id]}</b></div>
                 </div>
               </div>
             </div>
           ))}
-          {myActive.length===0 && <div className="text-white/60">No active entries yet.</div>}
+          {myActive.length===0 && <div className="text-white/60">{t('dashboard.noActiveEntries')}</div>}
         </div>
       </section>
 
       <section className="glass rounded-2xl p-6">
-        <h3 className="text-xl font-semibold">Ended Raffles</h3>
+        <h3 className="text-xl font-semibold">{t('dashboard.endedRaffles')}</h3>
         <div className="mt-4 grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {myEnded.map(r => (
             <div key={r.id} className="p-4 border border-white/10 rounded-xl bg-black/20">
               <div className="font-semibold">{r.title}</div>
-              <div className="text-sm text-white/70">Your tickets: <b>{profile.entries[r.id]}</b></div>
-              <div className="text-sm mt-1">Winner: <b className={r.winner===profile.username?"text-blue-light":"text-white/80"}>{r.winner || "TBD"}</b></div>
+              <div className="text-sm text-white/70">{t('dashboard.yourTickets')} <b>{profile.entries[r.id]}</b></div>
+              <div className="text-sm mt-1">{t('dashboard.winner')} <b className={r.winner===profile.username?"text-blue-light":"text-white/80"}>{r.winner || "TBD"}</b></div>
             </div>
           ))}
-          {myEnded.length===0 && <div className="text-white/60">No ended raffles yet.</div>}
+          {myEnded.length===0 && <div className="text-white/60">{t('dashboard.noEnded')}</div>}
         </div>
       </section>
 
       <section className="glass rounded-2xl p-6">
-        <h3 className="text-xl font-semibold">Wins</h3>
+        <h3 className="text-xl font-semibold">{t('dashboard.wins')}</h3>
         <div className="mt-4 grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {myWins.map(r => (
             <div key={r.id} className="p-4 border border-white/10 rounded-xl bg-black/20">
               <div className="font-semibold">{r.title}</div>
-              <div className="text-sm text-white/70">You won this raffle! 🎉</div>
+              <div className="text-sm text-white/70">{t('dashboard.youWon')}</div>
             </div>
           ))}
-          {myWins.length===0 && <div className="text-white/60">No wins yet. Good luck!</div>}
+          {myWins.length===0 && <div className="text-white/60">{t('dashboard.noWins')}</div>}
         </div>
       </section>
       {showDeposit && (

--- a/src/pages/HallOfFame.jsx
+++ b/src/pages/HallOfFame.jsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react'
 import { useAuth } from '../context/AuthContext'
 import { useRaffles } from '../context/RaffleContext'
+import { useTranslation } from 'react-i18next'
 
 function maskUsername(name, currentUser) {
   if (currentUser && currentUser.username === name) return name
@@ -29,6 +30,7 @@ export default function HallOfFame() {
   const { user, getAllUsers } = useAuth()
   const { raffles } = useRaffles()
   const [season, setSeason] = useState('week') // week, month, all
+  const { t } = useTranslation()
 
   const stats = useMemo(() => {
     const days = season === 'week' ? 7 : season === 'month' ? 30 : null
@@ -74,7 +76,7 @@ export default function HallOfFame() {
   const medal = idx => idx === 0 ? '🥇' : idx === 1 ? '🥈' : idx === 2 ? '🥉' : null
 
   const renderList = (list, formatter) => {
-    if (!list.length) return <div className="text-center py-6 text-white/60">No champions yet... be the first!</div>
+    if (!list.length) return <div className="text-center py-6 text-white/60">{t('hallOfFame.noChampions')}</div>
     const maxValue = list[0]?.value || 1
     return (
       <ul className="space-y-3">
@@ -104,26 +106,26 @@ export default function HallOfFame() {
   return (
     <div className="py-8">
       <section className="flex flex-col items-center justify-center text-center">
-        <h1 className="text-4xl md:text-6xl font-extrabold">Hall of Fame</h1>
-        <p className="text-white/70 mt-4 max-w-md">Celebrating our top raffle legends.</p>
+        <h1 className="text-4xl md:text-6xl font-extrabold">{t('hallOfFame.title')}</h1>
+        <p className="text-white/70 mt-4 max-w-md">{t('hallOfFame.tagline')}</p>
         <div className="mt-8 flex gap-3">
           <button onClick={() => setSeason('week')}
             className={`px-4 py-2 rounded-xl transition ${
               season==='week' ? 'bg-blue text-white' : 'bg-white/10 hover:bg-white/20'
             }`}>
-            Current Week
+            {t('hallOfFame.currentWeek')}
           </button>
           <button onClick={() => setSeason('month')}
             className={`px-4 py-2 rounded-xl transition ${
               season==='month' ? 'bg-blue text-white' : 'bg-white/10 hover:bg-white/20'
             }`}>
-            Current Month
+            {t('hallOfFame.currentMonth')}
           </button>
           <button onClick={() => setSeason('all')}
             className={`px-4 py-2 rounded-xl transition ${
               season==='all' ? 'bg-blue text-white' : 'bg-white/10 hover:bg-white/20'
             }`}>
-            All-Time
+            {t('hallOfFame.allTime')}
           </button>
         </div>
       </section>
@@ -137,7 +139,7 @@ export default function HallOfFame() {
               <div className="mt-2 font-semibold flex items-center gap-1">
                 {maskUsername(stats.mostTickets[0].username, user)} <span>🥇</span>
               </div>
-              <div className="text-sm text-white/60">Most Tickets</div>
+              <div className="text-sm text-white/60">{t('hallOfFame.championMostTickets')}</div>
             </div>
           )}
           {stats.mostWins[0] && (
@@ -146,7 +148,7 @@ export default function HallOfFame() {
               <div className="mt-2 font-semibold flex items-center gap-1">
                 {maskUsername(stats.mostWins[0].username, user)} <span>🥇</span>
               </div>
-              <div className="text-sm text-white/60">Most Wins</div>
+              <div className="text-sm text-white/60">{t('hallOfFame.championMostWins')}</div>
             </div>
           )}
           {stats.luckiest[0] && (
@@ -155,25 +157,25 @@ export default function HallOfFame() {
               <div className="mt-2 font-semibold flex items-center gap-1">
                 {maskUsername(stats.luckiest[0].username, user)} <span>🥇</span>
               </div>
-              <div className="text-sm text-white/60">Luckiest</div>
+              <div className="text-sm text-white/60">{t('hallOfFame.championLuckiest')}</div>
             </div>
           )}
         </section>
       ) : (
-        <div className="text-center text-white/60 mt-10">No champions yet... be the first!</div>
+        <div className="text-center text-white/60 mt-10">{t('hallOfFame.noChampions')}</div>
       )}
 
       <section className="mt-10 grid gap-6 md:grid-cols-3">
         <div className="glass rounded-2xl p-6 border border-white/10 shadow-glow">
-          <h3 className="font-semibold mb-4">🎟️ Most Tickets Bought</h3>
+          <h3 className="font-semibold mb-4">🎟️ {t('hallOfFame.mostTickets')}</h3>
           {renderList(stats.mostTickets, i => i.value)}
         </div>
         <div className="glass rounded-2xl p-6 border border-white/10 shadow-glow">
-          <h3 className="font-semibold mb-4">🏆 Most Wins</h3>
+          <h3 className="font-semibold mb-4">🏆 {t('hallOfFame.mostWins')}</h3>
           {renderList(stats.mostWins, i => i.value)}
         </div>
         <div className="glass rounded-2xl p-6 border border-white/10 shadow-glow">
-          <h3 className="font-semibold mb-4" title="Must have at least 5 tickets to qualify">🍀 Luckiest</h3>
+          <h3 className="font-semibold mb-4" title="Must have at least 5 tickets to qualify">🍀 {t('hallOfFame.luckiest')}</h3>
           {renderList(stats.luckiest, i => `${Math.round(i.value * 100)}%`)}
         </div>
       </section>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -2,10 +2,12 @@ import { Link } from 'react-router-dom'
 import { useRaffles } from '../context/RaffleContext'
 import { useAuth } from '../context/AuthContext'
 import Slideshow from '../components/Slideshow'
+import { useTranslation } from 'react-i18next'
 
 export default function Home() {
   const { raffles, topRaffles, purchase } = useRaffles()
   const { user } = useAuth()
+  const { t } = useTranslation()
 
   // lightweight stats for the hero
   const totalSold = raffles.reduce((s, r) => s + r.sold, 0)
@@ -28,23 +30,22 @@ export default function Home() {
         <div className="relative grid lg:grid-cols-2 gap-10 w-full">
           {/* LEFT: Text + CTA */}
           <div className="max-w-3xl">
-            <span className="text-sm uppercase tracking-widest text-blue-light">Play • Win • Repeat</span>
+            <span className="text-sm uppercase tracking-widest text-blue-light">{t('home.tagline')}</span>
             <h1 className="text-4xl md:text-6xl font-extrabold leading-tight mt-2">
               Win epic prizes with <span className="text-blue-light">Royale</span>
               <span className="text-claret">Raffles</span>
             </h1>
             <p className="text-white/70 mt-4 max-w-2xl">
-              Enter raffles using your on-site balance, discover trending prizes, and track your wins —
-              all in one playful, modern experience.
+              {t('home.description')}
             </p>
 
             <div className="mt-8 flex flex-wrap gap-3">
               <Link to="/raffles" className="px-6 py-3 rounded-2xl bg-blue hover:bg-blue-light">
-                Browse Raffles
+                {t('home.browse')}
               </Link>
               {!user && (
                 <Link to="/auth" className="px-6 py-3 rounded-2xl bg-claret hover:bg-claret-light">
-                  Login / Register
+                  {t('home.login')}
                 </Link>
               )}
             </div>
@@ -52,13 +53,13 @@ export default function Home() {
             {/* Stats chips */}
             <div className="mt-8 flex flex-wrap gap-3">
               <div className="px-4 py-2 rounded-2xl bg-white/10 border border-white/10 text-sm">
-                🎟️ <span className="text-white/80">Tickets sold:</span> <b>{totalSold}</b>
+                🎟️ <span className="text-white/80">{t('home.ticketsSold')}</span> <b>{totalSold}</b>
               </div>
               <div className="px-4 py-2 rounded-2xl bg-white/10 border border-white/10 text-sm">
-                🗂️ <span className="text-white/80">Active raffles:</span> <b>{totalRaffles}</b>
+                🗂️ <span className="text-white/80">{t('home.activeRaffles')}</span> <b>{totalRaffles}</b>
               </div>
               <div className="px-4 py-2 rounded-2xl bg-white/10 border border-white/10 text-sm">
-                🏆 <span className="text-white/80">Winners:</span> <b>{winners}</b>
+                🏆 <span className="text-white/80">{t('home.winners')}</span> <b>{winners}</b>
               </div>
             </div>
           </div>
@@ -66,27 +67,25 @@ export default function Home() {
           {/* RIGHT: Feature card (clean, optional) */}
           <div className="hidden lg:block">
             <div className="glass rounded-3xl p-6 border border-white/10">
-              <h3 className="text-xl font-semibold">How it works</h3>
+              <h3 className="text-xl font-semibold">{t('home.howItWorks')}</h3>
               <ol className="mt-3 space-y-2 text-white/80 text-sm list-decimal list-inside">
-                <li>Top up your on-site balance.</li>
-                <li>Pick a raffle & choose your tickets.</li>
-                <li>Watch the countdown — winners are drawn fairly.</li>
+                <li>{t('home.step1')}</li>
+                <li>{t('home.step2')}</li>
+                <li>{t('home.step3')}</li>
               </ol>
-              <div className="mt-4 text-xs text-white/60">
-                Max per user: <b>50%</b> of total tickets per raffle.
-              </div>
+              <div className="mt-4 text-xs text-white/60" dangerouslySetInnerHTML={{ __html: t('home.maxPerUser') }} />
               <div className="mt-5 grid grid-cols-3 gap-3 text-center">
                 <div className="p-3 rounded-xl bg-black/20 border border-white/10">
                   <div className="text-2xl">🔒</div>
-                  <div className="text-xs text-white/70 mt-1">Secure Top-Ups</div>
+                  <div className="text-xs text-white/70 mt-1">{t('home.secureTopups')}</div>
                 </div>
                 <div className="p-3 rounded-xl bg-black/20 border border-white/10">
                   <div className="text-2xl">⚖️</div>
-                  <div className="text-xs text-white/70 mt-1">Fair Draws</div>
+                  <div className="text-xs text-white/70 mt-1">{t('home.fairDraws')}</div>
                 </div>
                 <div className="p-3 rounded-xl bg-black/20 border border-white/10">
                   <div className="text-2xl">⚡</div>
-                  <div className="text-xs text-white/70 mt-1">Instant Entry</div>
+                  <div className="text-xs text-white/70 mt-1">{t('home.instantEntry')}</div>
                 </div>
               </div>
             </div>
@@ -96,20 +95,20 @@ export default function Home() {
 
       {/* TOP RAFFLES */}
       <section className="mt-10 space-y-4">
-        <h2 className="text-2xl font-bold">This Week&apos;s Top Raffles</h2>
+        <h2 className="text-2xl font-bold">{t('home.topRaffles')}</h2>
         <Slideshow items={topRaffles} onPurchase={purchase} />
       </section>
 
       {/* TRUST BAR (visible on mobile too) */}
       <section className="mt-8 grid sm:grid-cols-3 gap-3">
         <div className="glass rounded-2xl p-3 text-center text-sm">
-          🔒 <span className="text-white/80">Secure Top-Ups</span>
+          🔒 <span className="text-white/80">{t('home.trustSecure')}</span>
         </div>
         <div className="glass rounded-2xl p-3 text-center text-sm">
-          ⚖️ <span className="text-white/80">Fair, random winners</span>
+          ⚖️ <span className="text-white/80">{t('home.trustFair')}</span>
         </div>
         <div className="glass rounded-2xl p-3 text-center text-sm">
-          ⚡ <span className="text-white/80">Instant ticket purchase</span>
+          ⚡ <span className="text-white/80">{t('home.trustInstant')}</span>
         </div>
       </section>
     </div>

--- a/src/pages/RaffleDetails.jsx
+++ b/src/pages/RaffleDetails.jsx
@@ -4,6 +4,7 @@ import { useParams, Link, useNavigate } from 'react-router-dom'
 import { useRaffles } from '../context/RaffleContext'
 import { useAuth } from '../context/AuthContext'
 import BuyModal from '../components/BuyModal'
+import { useTranslation } from 'react-i18next'
 
 function mask(name) {
   if (!name) return ''
@@ -32,6 +33,7 @@ export default function RaffleDetails() {
   const { raffles, purchase } = useRaffles()
   const { user, getProfile } = useAuth()
   const nav = useNavigate()
+  const { t } = useTranslation()
 
   const r = useMemo(()=> raffles.find(x => String(x.id) === String(id)), [raffles, id])
   const [open, setOpen] = useState(false)
@@ -40,8 +42,8 @@ export default function RaffleDetails() {
     return (
       <div className="py-10">
         <div className="glass rounded-2xl p-6">
-          <h2 className="text-2xl font-bold">Raffle not found</h2>
-          <p className="text-white/70 mt-2">This raffle doesn't exist. Go back to the <Link className="text-blue-light underline" to="/raffles">raffles</Link> list.</p>
+          <h2 className="text-2xl font-bold">{t('raffleDetails.notFound')}</h2>
+          <p className="text-white/70 mt-2">{t('raffleDetails.notFoundDesc')} <Link className="text-blue-light underline" to="/raffles">{t('header.raffles')}</Link></p>
         </div>
       </div>
     )
@@ -61,32 +63,32 @@ export default function RaffleDetails() {
         <div className="glass rounded-2xl p-6 space-y-3">
           <h1 className="text-3xl font-extrabold">{r.title}</h1>
           <p className="text-white/70">{r.description}</p>
-          <div className="text-sm text-white/80">Estimated value: <b className="text-white">${r.value}</b></div>
-          <div className="text-sm text-white/80">Ticket price: <b className="text-blue-light">${r.ticketPrice.toFixed(2)}</b></div>
-          <div className="text-sm text-white/80">Progress: <b>{r.sold}</b> / {r.totalTickets} sold</div>
-          <div className="text-sm text-white/80">Time left: <b><Countdown endsAt={r.endsAt} ended={r.ended} /></b></div>
+          <div className="text-sm text-white/80">{t('raffleDetails.estimated')} <b className="text-white">${r.value}</b></div>
+          <div className="text-sm text-white/80">{t('raffleDetails.ticketPrice')} <b className="text-blue-light">${r.ticketPrice.toFixed(2)}</b></div>
+          <div className="text-sm text-white/80">{t('raffleDetails.progress')} <b>{r.sold}</b> / {r.totalTickets} sold</div>
+          <div className="text-sm text-white/80">{t('raffleDetails.timeLeft')} <b><Countdown endsAt={r.endsAt} ended={r.ended} /></b></div>
           {user && (
-            <div className="text-sm text-white/80">Your tickets: <b>{youHave}</b> • Max per user: <b>{maxPerUser}</b></div>
+            <div className="text-sm text-white/80">{t('raffleDetails.yourTickets')} <b>{youHave}</b> • {t('raffleDetails.maxPerUser')} <b>{maxPerUser}</b></div>
           )}
           <div className="pt-2 flex gap-3">
-            <button onClick={()=>nav(-1)} className="px-4 py-2 rounded-2xl bg-white/10 hover:bg-white/20">Back</button>
+            <button onClick={()=>nav(-1)} className="px-4 py-2 rounded-2xl bg-white/10 hover:bg-white/20">{t('raffleDetails.back')}</button>
             <button disabled={r.ended || available<=0} onClick={()=>setOpen(true)} className="px-4 py-2 rounded-2xl bg-claret hover:bg-claret-light disabled:opacity-50 disabled:cursor-not-allowed">
-              {r.ended ? 'Ended' : 'Enter Raffle'}
+              {r.ended ? t('raffleDetails.ended') : t('raffleDetails.enter')}
             </button>
           </div>
         </div>
       </div>
 
       <div className="glass rounded-2xl p-6">
-        <h2 className="text-xl font-semibold">Participants</h2>
-        <p className="text-white/70 text-sm">Recent entries (anonymized):</p>
+        <h2 className="text-xl font-semibold">{t('raffleDetails.participants')}</h2>
+        <p className="text-white/70 text-sm">{t('raffleDetails.recentEntries')}</p>
         <div className="mt-4 grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {(r.entries && r.entries.length>0) ? r.entries.map((e, i)=>(
             <div key={i} className="p-3 rounded-xl bg-black/20 border border-white/10 flex items-center justify-between">
               <span className="text-white/80">{mask(e.username)}</span>
               <span className="text-white/60 text-sm">× {e.count}</span>
             </div>
-          )) : <div className="text-white/60">No entries yet. Be the first!</div>}
+          )) : <div className="text-white/60">{t('raffleDetails.noEntries')}</div>}
         </div>
       </div>
 

--- a/src/pages/Raffles.jsx
+++ b/src/pages/Raffles.jsx
@@ -2,6 +2,7 @@
 import { useMemo, useState } from 'react'
 import { useRaffles } from '../context/RaffleContext'
 import RaffleCard from '../components/RaffleCard'
+import { useTranslation } from 'react-i18next'
 
 export default function Raffles() {
   const { raffles, purchase } = useRaffles()
@@ -9,6 +10,7 @@ export default function Raffles() {
   const [cat, setCat] = useState('All')
   const [status, setStatus] = useState('Active')
   const [sort, setSort] = useState('ending')
+  const { t } = useTranslation()
 
   const filtered = useMemo(() => {
     return raffles.filter(r => {
@@ -30,21 +32,21 @@ export default function Raffles() {
     <div className="py-8">
       <div className="glass rounded-2xl p-4 md:p-6">
         <div className="grid md:grid-cols-5 gap-3">
-          <input placeholder="Search raffles..." value={q} onChange={e=>setQ(e.target.value)}
+          <input placeholder={t('raffles.search')} value={q} onChange={e=>setQ(e.target.value)}
             className="md:col-span-2 bg-black/30 border border-white/10 rounded-xl px-3 py-2 outline-none" />
           <select value={cat} onChange={e=>setCat(e.target.value)} className="bg-black/30 border border-white/10 rounded-xl px-3 py-2">
-            <option>All</option>
+            <option>{t('raffles.all')}</option>
             {cats.map(c=><option key={c}>{c}</option>)}
           </select>
           <select value={status} onChange={e=>setStatus(e.target.value)} className="bg-black/30 border border-white/10 rounded-xl px-3 py-2">
-            <option>Active</option>
-            <option>Ended</option>
-            <option>All</option>
+            <option>{t('raffles.active')}</option>
+            <option>{t('raffles.ended')}</option>
+            <option>{t('raffles.all')}</option>
           </select>
           <select value={sort} onChange={e=>setSort(e.target.value)} className="bg-black/30 border border-white/10 rounded-xl px-3 py-2">
-            <option value="ending">Ending Soon</option>
-            <option value="progress">Most Popular</option>
-            <option value="value">Prize Value</option>
+            <option value="ending">{t('raffles.endingSoon')}</option>
+            <option value="progress">{t('raffles.mostPopular')}</option>
+            <option value="value">{t('raffles.prizeValue')}</option>
           </select>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- integrate i18next/react-i18next with English and Spanish resources
- wrap application with I18nextProvider
- translate headers and pages and add runtime language switcher

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c5b054171483329ea0eaa0d30be34e