### PR TITLE
feat: add social share options for free entry

### DIFF
--- a/src/components/RaffleCard.jsx
+++ b/src/components/RaffleCard.jsx
@@ -2,6 +2,7 @@
 import { useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import BuyModal from './BuyModal'
+import ShareModal from './ShareModal'
 import { useRaffles } from '../context/RaffleContext'
 
 function Progress({ sold, total }) {
@@ -15,6 +16,7 @@ function Progress({ sold, total }) {
 
 export default function RaffleCard({ r, onPurchase }) {
   const [open, setOpen] = useState(false)
+  const [shareOpen, setShareOpen] = useState(false)
   const { claimFreeTicket } = useRaffles()
   const timeLeft = useMemo(() => {
     const ms = r.endsAt - Date.now()
@@ -44,23 +46,20 @@ export default function RaffleCard({ r, onPurchase }) {
         <div className="flex items-center justify-between">
           <span className="text-white/80 text-sm">Ticket: <b className="text-blue-light">${r.ticketPrice.toFixed(2)}</b></span>
           <div className="flex gap-2">
-            <button disabled={r.ended} onClick={async ()=>{
-                const shareText = `I joined this raffle for free on Royale Raffles! ${window.location.origin}/raffles/${r.id}`
-                try {
-                  if (navigator.share) {
-                    await navigator.share({ title:r.title, text:shareText, url: window.location.origin + '/raffles/' + r.id })
-                  } else {
-                    const url = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}`
-                    window.open(url, '_blank')
-                  }
-                  claimFreeTicket(r.id)
-                } catch(e) {}
-              }} className="px-3 py-1.5 rounded-xl bg-blue-light hover:bg-blue-400 disabled:opacity-50 disabled:cursor-not-allowed text-black">Free Ticket</button>
+            <button disabled={r.ended} onClick={()=>setShareOpen(true)} className="px-3 py-1.5 rounded-xl bg-blue-light hover:bg-blue-400 disabled:opacity-50 disabled:cursor-not-allowed text-black">Free Ticket</button>
             <button disabled={r.ended} onClick={()=>setOpen(true)} className="px-3 py-1.5 rounded-xl bg-claret hover:bg-claret-light disabled:opacity-50 disabled:cursor-not-allowed">Enter</button>
           </div>
         </div>
       </div>
       {open && <BuyModal r={r} onClose={()=>setOpen(false)} onPurchase={onPurchase} />}
+      {shareOpen && (
+        <ShareModal
+          shareText={`I joined this raffle for free on Royale Raffles! ${window.location.origin}/raffles/${r.id}`}
+          url={window.location.origin + `/raffles/${r.id}`}
+          onClose={()=>setShareOpen(false)}
+          onShared={()=>claimFreeTicket(r.id)}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/ShareModal.jsx
+++ b/src/components/ShareModal.jsx
@@ -1,0 +1,47 @@
+import React from 'react'
+
+export default function ShareModal({ shareText, url, onClose, onShared }) {
+  const encodedUrl = encodeURIComponent(url)
+  const encodedText = encodeURIComponent(shareText)
+
+  const handleShare = (platform) => {
+    let shareUrl = ''
+    switch (platform) {
+      case 'twitter':
+        shareUrl = `https://twitter.com/intent/tweet?text=${encodedText}`
+        break
+      case 'facebook':
+        shareUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}&quote=${encodedText}`
+        break
+      case 'instagram':
+        shareUrl = `https://www.instagram.com/?url=${encodedUrl}`
+        break
+      default:
+        break
+    }
+    if (shareUrl) {
+      window.open(shareUrl, '_blank')
+      onShared()
+      onClose()
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/60 backdrop-blur flex items-center justify-center z-50 p-4">
+      <div className="glass rounded-2xl w-full max-w-md p-6 space-y-4">
+        <div className="flex items-start justify-between">
+          <h3 className="text-xl font-semibold">Share to claim free ticket</h3>
+          <button onClick={onClose} className="text-white/60 hover:text-white">✕</button>
+        </div>
+        <div className="flex flex-col gap-3">
+          <button onClick={() => handleShare('twitter')} className="px-4 py-2 rounded-xl bg-blue-light text-black hover:bg-blue-400">X (Twitter)</button>
+          <button onClick={() => handleShare('facebook')} className="px-4 py-2 rounded-xl bg-blue-600 text-white hover:bg-blue-700">Facebook</button>
+          <button onClick={() => handleShare('instagram')} className="px-4 py-2 rounded-xl bg-pink-500 text-white hover:bg-pink-600">Instagram</button>
+        </div>
+        <div className="flex justify-end">
+          <button onClick={onClose} className="px-3 py-1.5 rounded-xl bg-white/10 hover:bg-white/20">Cancel</button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/RaffleDetails.jsx
+++ b/src/pages/RaffleDetails.jsx
@@ -4,6 +4,7 @@ import { useParams, Link, useNavigate } from 'react-router-dom'
 import { useRaffles } from '../context/RaffleContext'
 import { useAuth } from '../context/AuthContext'
 import BuyModal from '../components/BuyModal'
+import ShareModal from '../components/ShareModal'
 import { useTranslation } from 'react-i18next'
 
 function mask(name) {
@@ -37,6 +38,7 @@ export default function RaffleDetails() {
 
   const r = useMemo(()=> raffles.find(x => String(x.id) === String(id)), [raffles, id])
   const [open, setOpen] = useState(false)
+  const [shareOpen, setShareOpen] = useState(false)
 
   if (!r) {
     return (
@@ -55,19 +57,10 @@ export default function RaffleDetails() {
   const available = r.totalTickets - r.sold
   const freeClaimed = profile?.freeEntries?.[r.id]
 
-  const handleShare = async () => {
-    const shareText = `I joined this raffle for free on Royale Raffles! ${window.location.origin}/raffles/${r.id}`
-    try {
-      if (navigator.share) {
-        await navigator.share({ title: r.title, text: shareText, url: window.location.origin + '/raffles/' + r.id })
-      } else {
-        const url = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}`
-        window.open(url, '_blank')
-      }
-      claimFreeTicket(r.id)
-    } catch (e) {
-      // ignore cancelled share
-    }
+  const shareText = `I joined this raffle for free on Royale Raffles! ${window.location.origin}/raffles/${r.id}`
+  const shareUrl = window.location.origin + '/raffles/' + r.id
+  const handleShared = () => {
+    claimFreeTicket(r.id)
   }
 
   return (
@@ -88,7 +81,7 @@ export default function RaffleDetails() {
           )}
           <div className="pt-2 flex gap-3 flex-wrap">
             <button onClick={()=>nav(-1)} className="px-4 py-2 rounded-2xl bg-white/10 hover:bg-white/20">{t('raffleDetails.back')}</button>
-            <button disabled={r.ended || available<=0 || freeClaimed} onClick={handleShare} className="px-4 py-2 rounded-2xl bg-blue-light hover:bg-blue-400 disabled:opacity-50 disabled:cursor-not-allowed text-black">
+            <button disabled={r.ended || available<=0 || freeClaimed} onClick={()=>setShareOpen(true)} className="px-4 py-2 rounded-2xl bg-blue-light hover:bg-blue-400 disabled:opacity-50 disabled:cursor-not-allowed text-black">
               {freeClaimed ? 'Free Ticket Claimed' : 'Share & Free Ticket'}
             </button>
             <button disabled={r.ended || available<=0} onClick={()=>setOpen(true)} className="px-4 py-2 rounded-2xl bg-claret hover:bg-claret-light disabled:opacity-50 disabled:cursor-not-allowed">
@@ -112,6 +105,7 @@ export default function RaffleDetails() {
       </div>
 
       {open && <BuyModal r={r} onClose={()=>setOpen(false)} onPurchase={purchase} />}
+      {shareOpen && <ShareModal shareText={shareText} url={shareUrl} onClose={()=>setShareOpen(false)} onShared={handleShared} />}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add ShareModal component to pick X (Twitter), Facebook, or Instagram for sharing
- wire ShareModal into raffle details and cards to grant free tickets after sharing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: 403 Forbidden fetching vite)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b60efad88332b39ddf09a5788dc7