### PR TITLE
feat: add badge system with sharing

### DIFF
--- a/src/components/BadgeGallery.jsx
+++ b/src/components/BadgeGallery.jsx
@@ -1,0 +1,55 @@
+import badges from '../data/badges'
+
+export default function BadgeGallery({ earned = [], username }) {
+  const shareBadge = (badge) => {
+    const canvas = document.createElement('canvas')
+    canvas.width = 600
+    canvas.height = 315
+    const ctx = canvas.getContext('2d')
+    ctx.fillStyle = '#1a1a1a'
+    ctx.fillRect(0, 0, canvas.width, canvas.height)
+    ctx.textAlign = 'center'
+    ctx.font = '72px sans-serif'
+    ctx.fillText(badge.icon, canvas.width / 2, 150)
+    ctx.font = '28px sans-serif'
+    ctx.fillStyle = '#ffffff'
+    ctx.fillText(`${username} earned ${badge.name}!`, canvas.width / 2, 250)
+    const dataUrl = canvas.toDataURL('image/png')
+    const link = document.createElement('a')
+    link.href = dataUrl
+    link.download = `badges/${badge.id}/share.png`
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
+  }
+
+  return (
+    <section className="glass rounded-2xl p-6">
+      <h3 className="text-xl font-semibold mb-4">Badges</h3>
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-6">
+        {badges.map((badge) => {
+          const unlocked = earned.includes(badge.id)
+          return (
+            <div
+              key={badge.id}
+              className={`flex flex-col items-center text-center p-4 border border-white/10 rounded-xl bg-black/20 transition-transform duration-300 ${unlocked ? 'opacity-100 hover:scale-105' : 'opacity-40'}`}
+            >
+              <div className="text-4xl">{badge.icon}</div>
+              <div className="mt-2 font-medium">{badge.name}</div>
+              {unlocked ? (
+                <button
+                  onClick={() => shareBadge(badge)}
+                  className="mt-2 px-2 py-1 text-xs rounded bg-blue-light text-black hover:bg-blue"
+                >
+                  Share Badge
+                </button>
+              ) : (
+                <div className="mt-2 text-xs text-white/60">Locked</div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/src/data/badges.js
+++ b/src/data/badges.js
@@ -1,0 +1,28 @@
+const badges = [
+  {
+    id: 'first-ticket',
+    name: 'First Ticket',
+    icon: '🎟️',
+    criteria: (profile) => {
+      const total = Object.values(profile.entries || {}).reduce((a, b) => a + b, 0)
+      return total > 0
+    }
+  },
+  {
+    id: 'big-spender',
+    name: 'Big Spender',
+    icon: '💰',
+    criteria: (profile) => {
+      const total = (profile.deposits || []).reduce((sum, d) => sum + d.amount, 0)
+      return total >= 100
+    }
+  },
+  {
+    id: 'winner',
+    name: 'Winner',
+    icon: '🏆',
+    criteria: (profile, raffles) => raffles.some(r => r.winner === profile.username)
+  }
+]
+
+export default badges

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -5,6 +5,8 @@ import { useRaffles } from '../context/RaffleContext'
 import { useNotify } from '../context/NotificationContext'
 import DepositModal from '../components/DepositModal'
 import { useTranslation } from 'react-i18next'
+import badges from '../data/badges'
+import BadgeGallery from '../components/BadgeGallery'
 
 export default function Dashboard() {
   const { getProfile, updateProfile } = useAuth()
@@ -14,6 +16,10 @@ export default function Dashboard() {
   const { notify, log } = useNotify()
   const profile = getProfile()
   const { t } = useTranslation()
+
+  const earnedBadges = useMemo(() => {
+    return badges.filter((b) => b.criteria(profile, raffles)).map((b) => b.id)
+  }, [profile, raffles])
 
   const myActive = useMemo(()=>{
     const ids = Object.keys(profile.entries || {}).map(n=>parseInt(n,10))
@@ -64,6 +70,8 @@ export default function Dashboard() {
           {(!profile.deposits || profile.deposits.length === 0) && <div className="text-white/60">{t('dashboard.noDeposits')}</div>}
         </div>
       </section>
+
+      <BadgeGallery earned={earnedBadges} username={profile.username} />
 
       <section className="glass rounded-2xl p-6">
         <h3 className="text-xl font-semibold">{t('dashboard.activeEntries')}</h3>


### PR DESCRIPTION
## Summary
- add badge metadata and evaluation logic
- display badges on dashboard with shareable images

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vite)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c87838a88332a0b3dafd9ac265a9