### PR TITLE
Improve accessibility for form inputs

### DIFF
--- a/src/components/BuyModal.jsx
+++ b/src/components/BuyModal.jsx
@@ -32,8 +32,17 @@ export default function BuyModal({ r, onClose, onPurchase }) {
         </div>
         <p className="text-white/80 text-sm">How many tickets would you like to buy for <b>{r.title}</b>?</p>
         <div className="space-y-2">
-          <input type="number" min="1" max={Math.min(maxByCap, available)} value={count}
-            onChange={e=>setCount(e.target.value)} className="w-full bg-black/30 border border-white/10 rounded-xl px-3 py-2 outline-none"/>
+          <label htmlFor="ticket-count" className="sr-only">Ticket count</label>
+          <input
+            id="ticket-count"
+            type="number"
+            min="1"
+            max={Math.min(maxByCap, available)}
+            value={count}
+            onChange={e=>setCount(e.target.value)}
+            className="w-full bg-black/30 border border-white/10 rounded-xl px-3 py-2 outline-none"
+            aria-label="Ticket count"
+          />
           <div className="text-xs text-white/70">Max per user: <b>{maxByCap}</b> • Available: <b>{available}</b></div>
           <div className="text-sm">Total: <b className="text-blue-light">${(r.ticketPrice * (parseInt(count||0,10)||0)).toFixed(2)}</b></div>
           {err && <div className="text-sm text-red-400">{err}</div>}

--- a/src/components/DepositModal.jsx
+++ b/src/components/DepositModal.jsx
@@ -48,31 +48,47 @@ export default function DepositModal({ amount, onClose, onSuccess }) {
               </div>
               <div className="space-y-2">
                 <div className="text-sm text-white/70">Amount: <b className="text-blue-light">${amount.toFixed(2)}</b></div>
+                <label htmlFor="card-number" className="sr-only">Card Number</label>
                 <input
-                placeholder="Card Number"
-                value={card.number}
-                onChange={e => setCard({ ...card, number: e.target.value })}
-                className="w-full bg-black/30 border border-white/10 rounded-xl px-3 py-2 outline-none"
-              />
+                  id="card-number"
+                  placeholder="Card Number"
+                  value={card.number}
+                  onChange={e => setCard({ ...card, number: e.target.value })}
+                  className="w-full bg-black/30 border border-white/10 rounded-xl px-3 py-2 outline-none"
+                  aria-label="Card Number"
+                />
               <div className="flex gap-2">
-                <input
-                  placeholder="MM/YY"
-                  value={card.expiry}
-                  onChange={e => setCard({ ...card, expiry: e.target.value })}
-                  className="flex-1 bg-black/30 border border-white/10 rounded-xl px-3 py-2 outline-none"
-                />
-                <input
-                  placeholder="CVC"
-                  value={card.cvc}
-                  onChange={e => setCard({ ...card, cvc: e.target.value })}
-                  className="flex-1 bg-black/30 border border-white/10 rounded-xl px-3 py-2 outline-none"
-                />
+                <div className="flex-1">
+                  <label htmlFor="card-expiry" className="sr-only">Expiry date</label>
+                  <input
+                    id="card-expiry"
+                    placeholder="MM/YY"
+                    value={card.expiry}
+                    onChange={e => setCard({ ...card, expiry: e.target.value })}
+                    className="w-full bg-black/30 border border-white/10 rounded-xl px-3 py-2 outline-none"
+                    aria-label="Expiry date"
+                  />
+                </div>
+                <div className="flex-1">
+                  <label htmlFor="card-cvc" className="sr-only">CVC</label>
+                  <input
+                    id="card-cvc"
+                    placeholder="CVC"
+                    value={card.cvc}
+                    onChange={e => setCard({ ...card, cvc: e.target.value })}
+                    className="w-full bg-black/30 border border-white/10 rounded-xl px-3 py-2 outline-none"
+                    aria-label="CVC"
+                  />
+                </div>
               </div>
+              <label htmlFor="card-name" className="sr-only">Name on Card</label>
               <input
+                id="card-name"
                 placeholder="Name on Card"
                 value={card.name}
                 onChange={e => setCard({ ...card, name: e.target.value })}
                 className="w-full bg-black/30 border border-white/10 rounded-xl px-3 py-2 outline-none"
+                aria-label="Name on Card"
               />
               {err && <div className="text-sm text-red-400">{err}</div>}
             </div>

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -70,14 +70,81 @@ function RaffleEditor({ data, onClose, onSave }) {
           <button onClick={onClose} className="text-white/60 hover:text-white">✕</button>
         </div>
         <div className="grid grid-cols-2 gap-3">
-          <input className="bg-black/30 border border-white/10 rounded-xl px-3 py-2 col-span-2" placeholder={t('admin.title')} value={form.title} onChange={e=>set('title', e.target.value)} />
-          <input className="bg-black/30 border border-white/10 rounded-xl px-3 py-2 col-span-2" placeholder={t('admin.imageUrl')} value={form.image} onChange={e=>set('image', e.target.value)} />
-          <textarea className="bg-black/30 border border-white/10 rounded-xl px-3 py-2 col-span-2" placeholder={t('admin.description')} value={form.description} onChange={e=>set('description', e.target.value)} />
-          <input type="number" className="bg-black/30 border border-white/10 rounded-xl px-3 py-2" placeholder={t('admin.value')} value={form.value} onChange={e=>set('value', parseFloat(e.target.value||0))} />
-          <input type="number" className="bg-black/30 border border-white/10 rounded-xl px-3 py-2" placeholder={t('admin.ticketPrice')} value={form.ticketPrice} onChange={e=>set('ticketPrice', parseFloat(e.target.value||0))} />
-          <input type="number" className="bg-black/30 border border-white/10 rounded-xl px-3 py-2" placeholder={t('admin.totalTickets')} value={form.totalTickets} onChange={e=>set('totalTickets', parseInt(e.target.value||0,10))} />
-          <input type="datetime-local" className="bg-black/30 border border-white/10 rounded-xl px-3 py-2 col-span-2" value={new Date(form.endsAt).toISOString().slice(0,16)} onChange={e=>set('endsAt', new Date(e.target.value).getTime())} />
-          <input className="bg-black/30 border border-white/10 rounded-xl px-3 py-2 col-span-2" placeholder={t('admin.category')} value={form.category||'General'} onChange={e=>set('category', e.target.value)} />
+          <label htmlFor="raffle-title" className="sr-only">{t('admin.title')}</label>
+          <input
+            id="raffle-title"
+            className="bg-black/30 border border-white/10 rounded-xl px-3 py-2 col-span-2"
+            placeholder={t('admin.title')}
+            aria-label={t('admin.title')}
+            value={form.title}
+            onChange={e=>set('title', e.target.value)}
+          />
+          <label htmlFor="raffle-image" className="sr-only">{t('admin.imageUrl')}</label>
+          <input
+            id="raffle-image"
+            className="bg-black/30 border border-white/10 rounded-xl px-3 py-2 col-span-2"
+            placeholder={t('admin.imageUrl')}
+            aria-label={t('admin.imageUrl')}
+            value={form.image}
+            onChange={e=>set('image', e.target.value)}
+          />
+          <label htmlFor="raffle-description" className="sr-only">{t('admin.description')}</label>
+          <textarea
+            id="raffle-description"
+            className="bg-black/30 border border-white/10 rounded-xl px-3 py-2 col-span-2"
+            placeholder={t('admin.description')}
+            aria-label={t('admin.description')}
+            value={form.description}
+            onChange={e=>set('description', e.target.value)}
+          />
+          <label htmlFor="raffle-value" className="sr-only">{t('admin.value')}</label>
+          <input
+            id="raffle-value"
+            type="number"
+            className="bg-black/30 border border-white/10 rounded-xl px-3 py-2"
+            placeholder={t('admin.value')}
+            aria-label={t('admin.value')}
+            value={form.value}
+            onChange={e=>set('value', parseFloat(e.target.value||0))}
+          />
+          <label htmlFor="raffle-ticketPrice" className="sr-only">{t('admin.ticketPrice')}</label>
+          <input
+            id="raffle-ticketPrice"
+            type="number"
+            className="bg-black/30 border border-white/10 rounded-xl px-3 py-2"
+            placeholder={t('admin.ticketPrice')}
+            aria-label={t('admin.ticketPrice')}
+            value={form.ticketPrice}
+            onChange={e=>set('ticketPrice', parseFloat(e.target.value||0))}
+          />
+          <label htmlFor="raffle-totalTickets" className="sr-only">{t('admin.totalTickets')}</label>
+          <input
+            id="raffle-totalTickets"
+            type="number"
+            className="bg-black/30 border border-white/10 rounded-xl px-3 py-2"
+            placeholder={t('admin.totalTickets')}
+            aria-label={t('admin.totalTickets')}
+            value={form.totalTickets}
+            onChange={e=>set('totalTickets', parseInt(e.target.value||0,10))}
+          />
+          <label htmlFor="raffle-endsAt" className="sr-only">End Date</label>
+          <input
+            id="raffle-endsAt"
+            type="datetime-local"
+            className="bg-black/30 border border-white/10 rounded-xl px-3 py-2 col-span-2"
+            value={new Date(form.endsAt).toISOString().slice(0,16)}
+            onChange={e=>set('endsAt', new Date(e.target.value).getTime())}
+            aria-label="End Date"
+          />
+          <label htmlFor="raffle-category" className="sr-only">{t('admin.category')}</label>
+          <input
+            id="raffle-category"
+            className="bg-black/30 border border-white/10 rounded-xl px-3 py-2 col-span-2"
+            placeholder={t('admin.category')}
+            aria-label={t('admin.category')}
+            value={form.category||'General'}
+            onChange={e=>set('category', e.target.value)}
+          />
         </div>
         <div className="flex justify-end gap-2 pt-2">
           <button className="px-3 py-1.5 rounded-xl bg-white/10 hover:bg-white/20" onClick={onClose}>{t('admin.cancel')}</button>

--- a/src/pages/Auth.jsx
+++ b/src/pages/Auth.jsx
@@ -31,10 +31,25 @@ export default function Auth() {
         <h2 className="text-2xl font-bold">{mode==='login'?t('auth.login'):t('auth.register')}</h2>
         <p className="text-white/70 text-sm mt-1" dangerouslySetInnerHTML={{ __html: t('auth.demo') }} />
         <div className="space-y-3 mt-6">
-          <input placeholder={t('auth.username')} value={username} onChange={e=>setUsername(e.target.value)}
-            className="w-full bg-black/30 border border-white/10 rounded-xl px-3 py-2 outline-none" />
-          <input placeholder={t('auth.password')} type="password" value={password} onChange={e=>setPassword(e.target.value)}
-            className="w-full bg-black/30 border border-white/10 rounded-xl px-3 py-2 outline-none" />
+          <label htmlFor="auth-username" className="sr-only">{t('auth.username')}</label>
+          <input
+            id="auth-username"
+            placeholder={t('auth.username')}
+            aria-label={t('auth.username')}
+            value={username}
+            onChange={e=>setUsername(e.target.value)}
+            className="w-full bg-black/30 border border-white/10 rounded-xl px-3 py-2 outline-none"
+          />
+          <label htmlFor="auth-password" className="sr-only">{t('auth.password')}</label>
+          <input
+            id="auth-password"
+            placeholder={t('auth.password')}
+            aria-label={t('auth.password')}
+            type="password"
+            value={password}
+            onChange={e=>setPassword(e.target.value)}
+            className="w-full bg-black/30 border border-white/10 rounded-xl px-3 py-2 outline-none"
+          />
           {error && <div className="text-sm text-red-400">{error}</div>}
           <button onClick={handle} className="w-full px-4 py-2 rounded-2xl bg-blue hover:bg-blue-light">{mode==='login'?t('auth.login'):t('auth.createAccount')}</button>
           <button onClick={()=>{setMode(mode==='login'?'register':'login'); setError('')}} className="w-full px-4 py-2 rounded-2xl bg-white/10 hover:bg-white/20">

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -57,7 +57,16 @@ export default function Dashboard() {
         <h2 className="text-2xl font-bold">{t('dashboard.myWallet')}</h2>
         <div className="mt-2 text-white/80">{t('dashboard.currentBalance')} <b className="text-blue-light">${profile.balance.toFixed(2)}</b></div>
         <div className="mt-3 flex items-center gap-2">
-          <input type="number" min="1" value={amt} onChange={e=>setAmt(e.target.value)} className="bg-black/30 border border-white/10 rounded-xl px-3 py-2"/>
+          <label htmlFor="deposit-amount" className="sr-only">Amount</label>
+          <input
+            id="deposit-amount"
+            type="number"
+            min="1"
+            value={amt}
+            onChange={e=>setAmt(e.target.value)}
+            className="bg-black/30 border border-white/10 rounded-xl px-3 py-2"
+            aria-label="Amount"
+          />
           <button onClick={openDeposit} className="px-4 py-2 rounded-xl bg-blue hover:bg-blue-light">{t('dashboard.topUp')}</button>
         </div>
         <div className="mt-4 space-y-1 text-sm text-white/70">

--- a/src/pages/Raffles.jsx
+++ b/src/pages/Raffles.jsx
@@ -32,8 +32,15 @@ export default function Raffles() {
     <div className="py-8">
       <div className="glass rounded-2xl p-4 md:p-6">
         <div className="grid md:grid-cols-5 gap-3">
-          <input placeholder={t('raffles.search')} value={q} onChange={e=>setQ(e.target.value)}
-            className="md:col-span-2 bg-black/30 border border-white/10 rounded-xl px-3 py-2 outline-none" />
+          <label htmlFor="raffle-search" className="sr-only">{t('raffles.search')}</label>
+          <input
+            id="raffle-search"
+            placeholder={t('raffles.search')}
+            aria-label={t('raffles.search')}
+            value={q}
+            onChange={e=>setQ(e.target.value)}
+            className="md:col-span-2 bg-black/30 border border-white/10 rounded-xl px-3 py-2 outline-none"
+          />
           <select value={cat} onChange={e=>setCat(e.target.value)} className="bg-black/30 border border-white/10 rounded-xl px-3 py-2">
             <option>{t('raffles.all')}</option>
             {cats.map(c=><option key={c}>{c}</option>)}


### PR DESCRIPTION
## Summary
- add hidden labels to modal and page inputs
- provide aria labels for fields using placeholders
- apply consistent identifiers in admin raffle editor

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: 403 Forbidden fetching vite)


------
https://chatgpt.com/codex/tasks/task_e_68c5cd08e49083328a609a5614aa3ff9