### PR TITLE
Add rewrite rule to vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "framework": "vite",
   "buildCommand": "npm install --include=dev && npm run build",
-  "outputDirectory": "dist"
+  "outputDirectory": "dist",
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
 }


### PR DESCRIPTION
## Summary
- route all unmatched paths to `index.html` through Vercel rewrites

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vite)*

------
https://chatgpt.com/codex/tasks/task_e_68c65d95ccc883328d8e33ad1d06c0c2