### PR TITLE
Add profile settings page with user avatar and email fields

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import Home from './pages/Home'
 import Raffles from './pages/Raffles'
 import RaffleDetails from './pages/RaffleDetails'
 import Dashboard from './pages/Dashboard'
+import ProfileSettings from './pages/ProfileSettings'
 import Auth from './pages/Auth'
 import Admin from './pages/Admin'
 import HallOfFame from './pages/HallOfFame'
@@ -34,6 +35,7 @@ export default function App() {
           <Route path="/hall-of-fame" element={<HallOfFame />} />
           <Route path="/community-vote" element={<CommunityVote />} />
           <Route path="/dashboard" element={<PrivateRoute><Dashboard /></PrivateRoute>} />
+          <Route path="/settings" element={<PrivateRoute><ProfileSettings /></PrivateRoute>} />
           <Route path="/auth" element={<Auth />} />
             <Route path="/admin" element={<Admin />} />
           <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -26,6 +26,8 @@ const DEMO_USER = {
   weeklyStreak: 0,
   lastLogin: null,
   lastWeek: null,
+  avatar: '',
+  email: '',
 }
 
 function loadUsers() {
@@ -34,10 +36,10 @@ function loadUsers() {
 
   if (!users['demo']) {
     users['demo'] = DEMO_USER
-    users['admin'] = { username:'admin', password:'admin', balance: 10000, entries:{}, wins:[], history:[], deposits:[], freeEntries:{}, isAdmin:true }
-    users['alice'] = { username:'alice', password:'alice', balance: 800, entries:{}, wins:[], history:[], deposits:[], freeEntries:{}, isAdmin:false }
-    users['bob'] = { username:'bob', password:'bob', balance: 600, entries:{}, wins:[], history:[], deposits:[], freeEntries:{}, isAdmin:false }
-    users['charlie'] = { username:'charlie', password:'charlie', balance: 900, entries:{}, wins:[], history:[], deposits:[], freeEntries:{}, isAdmin:false }
+    users['admin'] = { username:'admin', password:'admin', balance: 10000, entries:{}, wins:[], history:[], deposits:[], freeEntries:{}, isAdmin:true, avatar:'', email:'' }
+    users['alice'] = { username:'alice', password:'alice', balance: 800, entries:{}, wins:[], history:[], deposits:[], freeEntries:{}, isAdmin:false, avatar:'', email:'' }
+    users['bob'] = { username:'bob', password:'bob', balance: 600, entries:{}, wins:[], history:[], deposits:[], freeEntries:{}, isAdmin:false, avatar:'', email:'' }
+    users['charlie'] = { username:'charlie', password:'charlie', balance: 900, entries:{}, wins:[], history:[], deposits:[], freeEntries:{}, isAdmin:false, avatar:'', email:'' }
     localStorage.setItem('rr_users', JSON.stringify(users))
   }
 
@@ -70,6 +72,14 @@ function loadUsers() {
     }
     if (u.lastWeek === undefined) {
       u.lastWeek = null
+      changed = true
+    }
+    if (u.avatar === undefined) {
+      u.avatar = ''
+      changed = true
+    }
+    if (u.email === undefined) {
+      u.email = ''
       changed = true
     }
   })
@@ -137,6 +147,8 @@ export function AuthProvider({ children }) {
       weeklyStreak: 0,
       lastLogin: null,
       lastWeek: null,
+      avatar: '',
+      email: '',
     }
     users[username] = newUser
     saveUsers(users)
@@ -206,8 +218,20 @@ export function AuthProvider({ children }) {
     updateProfile(u => ({ ...u, xp: (u.xp || 0) + amount }))
   }
 
+  const updateAvatar = (avatar) => {
+    updateProfile(u => ({ ...u, avatar }))
+  }
+
+  const updateEmail = (email) => {
+    updateProfile(u => ({ ...u, email }))
+  }
+
+  const updatePassword = (password) => {
+    updateProfile(u => ({ ...u, password }))
+  }
+
   return (
-    <AuthCtx.Provider value={{ user, login, register, logout, getProfile, updateProfile, getAllUsers, updateUser, toggleAdmin, deleteUser, addXP }}>
+    <AuthCtx.Provider value={{ user, login, register, logout, getProfile, updateProfile, getAllUsers, updateUser, toggleAdmin, deleteUser, addXP, updateAvatar, updateEmail, updatePassword }}>
       {children}
     </AuthCtx.Provider>
   )

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,5 +1,6 @@
 
 import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext'
 import { useRaffles } from '../context/RaffleContext'
 import { useNotify } from '../context/NotificationContext'
@@ -53,6 +54,9 @@ export default function Dashboard() {
 
   return (
     <div className="py-8 space-y-8">
+      <div className="flex justify-end">
+        <Link to="/settings" className="px-4 py-2 rounded-xl bg-blue hover:bg-blue-light">Settings</Link>
+      </div>
       <section className="glass rounded-2xl p-6">
         <h2 className="text-2xl font-bold">{t('dashboard.myWallet')}</h2>
         <div className="mt-2 text-white/80">{t('dashboard.currentBalance')} <b className="text-blue-light">${profile.balance.toFixed(2)}</b></div>

--- a/src/pages/ProfileSettings.jsx
+++ b/src/pages/ProfileSettings.jsx
@@ -1,0 +1,56 @@
+import { useState } from 'react'
+import { useAuth } from '../context/AuthContext'
+
+export default function ProfileSettings() {
+  const { getProfile, updateAvatar, updateEmail, updatePassword } = useAuth()
+  const profile = getProfile()
+  const [avatar, setAvatar] = useState(profile.avatar || '')
+  const [email, setEmail] = useState(profile.email || '')
+  const [password, setPassword] = useState(profile.password || '')
+
+  const handleSubmit = (e) => {
+    e.preventDefault()
+    updateAvatar(avatar)
+    updateEmail(email)
+    updatePassword(password)
+  }
+
+  return (
+    <div className="py-8 flex justify-center">
+      <form onSubmit={handleSubmit} className="glass p-6 rounded-2xl space-y-4 w-full max-w-md">
+        <h2 className="text-2xl font-bold">Profile Settings</h2>
+        <div>
+          <label htmlFor="avatar" className="block text-sm mb-1">Avatar URL</label>
+          <input
+            id="avatar"
+            value={avatar}
+            onChange={e => setAvatar(e.target.value)}
+            className="w-full bg-black/30 border border-white/10 rounded-xl px-3 py-2"
+          />
+        </div>
+        <div>
+          <label htmlFor="email" className="block text-sm mb-1">Email</label>
+          <input
+            id="email"
+            type="email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            className="w-full bg-black/30 border border-white/10 rounded-xl px-3 py-2"
+          />
+        </div>
+        <div>
+          <label htmlFor="password" className="block text-sm mb-1">Password</label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            className="w-full bg-black/30 border border-white/10 rounded-xl px-3 py-2"
+          />
+        </div>
+        <button type="submit" className="px-4 py-2 rounded-xl bg-blue hover:bg-blue-light w-full">Save</button>
+      </form>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- Extend AuthContext user records with new `avatar` and `email` fields
- Add update helpers to modify avatar, email, and password in local storage
- Introduce `ProfileSettings` page and route with dashboard link for editing profile settings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vite)*

------
https://chatgpt.com/codex/tasks/task_e_68c680c58f7483328fc44dc26b46195b