### PR TITLE
feat: role-based auth and admin checks

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -4,7 +4,7 @@ import { useAuth } from '../context/AuthContext'
 import { useTranslation } from 'react-i18next'
 
 export default function Header() {
-  const { user, logout, getProfile } = useAuth()
+  const { user, logout, getProfile, hasRole } = useAuth()
   const nav = useNavigate()
   const balance = user ? getProfile()?.balance ?? 0 : 0
   const { t, i18n } = useTranslation()
@@ -21,7 +21,7 @@ export default function Header() {
           <NavLink to="/community-vote" className={({isActive})=>isActive?'text-blue-light':'text-white/80 hover:text-white'}>{t('header.community')}</NavLink>
           <NavLink to="/hall-of-fame" className={({isActive})=>isActive?'text-blue-light':'text-white/80 hover:text-white'}>{t('header.hall')}</NavLink>
           {user && <NavLink to="/dashboard" className={({isActive})=>isActive?'text-blue-light':'text-white/80 hover:text-white'}>{t('header.account')}</NavLink>}
-          {user?.isAdmin && <NavLink to="/admin" className={({isActive})=>isActive?'text-blue-light':'text-white/80 hover:text-white'}>{t('header.admin')}</NavLink>}
+            {hasRole('admin') && <NavLink to="/admin" className={({isActive})=>isActive?'text-blue-light':'text-white/80 hover:text-white'}>{t('header.admin')}</NavLink>}
         </nav>
         <div className="flex items-center gap-3">
           {user ? (

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -7,13 +7,13 @@ import { useNotify } from '../context/NotificationContext'
 import { useTranslation } from 'react-i18next'
 
 export default function Admin() {
-  const { user, getAllUsers } = useAuth()
+  const { getAllUsers, hasRole } = useAuth()
   const { raffles, upsertRaffle, endRaffleManually } = useRaffles()
   const { notify } = useNotify()
   const [tab, setTab] = useState('raffles')
   const { t } = useTranslation()
 
-  if (!user || !user.isAdmin) return <Navigate to="/auth" replace />
+  if (!hasRole('admin')) return <Navigate to="/auth" replace />
 
   return (
     <div className="py-8 space-y-6">
@@ -206,7 +206,7 @@ function UsersAdmin({ users }) {
               <tr key={u.username} className="border-t border-white/10">
                 <td className="p-2">{u.username}</td>
                 <td className="p-2">${(u.balance||0).toFixed(2)}</td>
-                <td className="p-2">{u.isAdmin?t('admin.yes'):t('admin.no')}</td>
+                <td className="p-2">{u.roles?.includes('admin')?t('admin.yes'):t('admin.no')}</td>
                 <td className="p-2">
                   <div className="flex gap-2">
                     <button className="px-3 py-1.5 rounded-xl bg-white/10 hover:bg-white/20" onClick={()=>setEditing(u)}>{t('admin.edit')}</button>


### PR DESCRIPTION
## Summary
- switch `isAdmin` boolean to role array in auth context
- add `hasRole` helper and update login, register and admin toggle to persist roles
- guard admin routes and navigation using role checks instead of `isAdmin`

## Testing
- `npm test` (fails: Missing script: "test")
- `node node_modules/vite/bin/vite.js build` (fails: Cannot find module @rollup/rollup-linux-x64-gnu)


------
https://chatgpt.com/codex/tasks/task_e_68c682ee0ff08332be8933aeaf7351c0