### PR TITLE
Add purchase history tracking

### DIFF
--- a/src/components/EntryHistory.jsx
+++ b/src/components/EntryHistory.jsx
@@ -1,0 +1,20 @@
+import { useAuth } from '../context/AuthContext'
+
+export default function EntryHistory() {
+  const { getProfile } = useAuth()
+  const profile = getProfile()
+  const history = profile?.history || []
+
+  return (
+    <div className="mt-4 space-y-1 text-sm text-white/70">
+      {history.map((h) => (
+        <div key={h.id} className="flex justify-between border-b border-white/10 pb-1">
+          <span>{h.title}</span>
+          <span className="text-white">{h.count}</span>
+          <span>{new Date(h.date).toLocaleString()}</span>
+        </div>
+      ))}
+      {history.length === 0 && <div className="text-white/60">No purchases yet.</div>}
+    </div>
+  )
+}

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -194,6 +194,16 @@ export function AuthProvider({ children }) {
     saveUsers(users)
   }
 
+  const addHistory = (raffleId, title, count) => {
+    updateProfile(u => ({
+      ...u,
+      history: [
+        ...(u.history || []),
+        { id: Date.now(), raffleId, title, count, date: new Date().toISOString() }
+      ]
+    }))
+  }
+
   const updateUser = (username, updates) => {
     const users = loadUsers()
     if (!users[username]) return
@@ -254,7 +264,7 @@ export function AuthProvider({ children }) {
   }
 
   return (
-    <AuthCtx.Provider value={{ user, login, register, logout, getProfile, updateProfile, getAllUsers, updateUser, toggleAdmin, deleteUser, addXP, updateAvatar, updateEmail, updatePassword, hasRole }}>
+    <AuthCtx.Provider value={{ user, login, register, logout, getProfile, updateProfile, getAllUsers, updateUser, toggleAdmin, deleteUser, addXP, updateAvatar, updateEmail, updatePassword, hasRole, addHistory }}>
       {children}
     </AuthCtx.Provider>
   )

--- a/src/context/RaffleContext.jsx
+++ b/src/context/RaffleContext.jsx
@@ -33,7 +33,7 @@ function saveRaffles(raffles) {
 export function RaffleProvider({ children }) {
     const { notify, log } = useNotify()
   const [raffles, setRaffles] = useState([])
-  const { user, getProfile, updateProfile } = useAuth()
+  const { user, getProfile, updateProfile, addHistory } = useAuth()
 
   useEffect(() => {
     setRaffles(loadRaffles())
@@ -101,6 +101,8 @@ export function RaffleProvider({ children }) {
       entries[raffleId] = (entries[raffleId] || 0) + count
       return { ...u, balance: u.balance - price, entries }
     })
+
+    addHistory(raffleId, r.title, count)
 
     notify(`Purchased ${count} ticket(s) for ${r.title}`); log({ type:'purchase', raffleId: raffleId, count, user: prof.username }); return { ok: true }
   }

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -8,6 +8,7 @@ import DepositModal from '../components/DepositModal'
 import { useTranslation } from 'react-i18next'
 import badges, { dailyChallenges, weeklyChallenges } from '../data/badges'
 import BadgeGallery from '../components/BadgeGallery'
+import EntryHistory from '../components/EntryHistory'
 
 export default function Dashboard() {
   const { getProfile, updateProfile } = useAuth()
@@ -182,6 +183,11 @@ export default function Dashboard() {
           ))}
           {myWins.length===0 && <div className="text-white/60">{t('dashboard.noWins')}</div>}
         </div>
+      </section>
+
+      <section className="glass rounded-2xl p-6">
+        <h3 className="text-xl font-semibold">Purchase History</h3>
+        <EntryHistory />
       </section>
       {showDeposit && (
         <DepositModal


### PR DESCRIPTION
## Summary
- Track ticket purchases via new `addHistory` in AuthContext and RaffleContext integration
- Display purchase history on dashboard using new `EntryHistory` component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: 403 Forbidden fetching vite)*
- `node_modules/.bin/vite build` *(fails: MODULE_NOT_FOUND for rollup native)*

------
https://chatgpt.com/codex/tasks/task_e_68c6869b20708332ae13e741c7951d5f