### PR TITLE
Fix footer imports causing build failure

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,9 +1,14 @@
+import { Link } from 'react-router-dom'
+
 export default function Footer() {
   return (
     <footer className="mt-16 border-t border-white/10 bg-black/30">
       <div className="max-w-7xl mx-auto px-4 md:px-8 py-12 text-white/60 text-sm grid grid-cols-1 md:grid-cols-3 gap-8">
         <div className="space-y-4">
-          <img src={logo} alt="Royal Raffles logo" className="h-10 w-auto" />
+          <Link to="/" className="block text-2xl font-extrabold tracking-tight">
+            <span className="text-claret">Royale</span>
+            <span className="text-blue-light">Raffles</span>
+          </Link>
           <p className="text-white">UK prize competitions • 18+ only</p>
           <p className="text-xs">© {new Date().getFullYear()} RoyaleRaffles. All rights reserved.</p>
         </div>


### PR DESCRIPTION
## Summary
- import Link in Footer and remove missing logo reference
- render text-based brand link in footer

## Testing
- `node node_modules/vite/bin/vite.js build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68c6cb22e4d08332bb5e9c27a4397dad