### PR TITLE
Update compliance copy and hide activity feed

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,6 @@
 import { Routes, Route, Navigate } from 'react-router-dom'
 import Header from './components/Header'
 import Footer from './components/Footer'
-import ActivityFeed from './components/ActivityFeed'
 import Home from './pages/Home'
 import Raffles from './pages/Raffles'
 import RaffleDetails from './pages/RaffleDetails'
@@ -29,7 +28,6 @@ export default function App() {
   return (
     <div className={`text-white min-h-screen flex flex-col transition-[padding] duration-300 ${collapsed ? '' : 'sm:pr-[360px]'}`}>
       <Header />
-      <ActivityFeed />
       <main className="flex-1 px-4 md:px-8 max-w-7xl mx-auto w-full">
         <Routes>
           <Route path="/" element={<Home />} />

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -7,10 +7,7 @@ export default function Footer() {
         <div className="space-y-4">
           <Link to="/" className="flex items-center gap-3 text-2xl font-extrabold tracking-tight text-white">
             <img src="/logo.png" alt="Royale Raffles" className="h-10 w-10 rounded-lg object-contain border border-white/10" />
-            <div>
-              <span className="text-claret">Royale</span>
-              <span className="text-blue-light">Raffles</span>
-            </div>
+            <span className="sr-only">Royale Raffles</span>
           </Link>
           <p className="text-white/80">UK prize competitions • 18+ only • Free entry available</p>
           <p className="text-xs text-white/50">© {new Date().getFullYear()} Royale Raffles. All rights reserved.</p>
@@ -35,8 +32,7 @@ export default function Footer() {
         <div>
           <h3 className="text-white font-semibold mb-4">Company</h3>
           <p className="text-white/80">Operated by Northedge Group Ltd</p>
-          <p className="text-white/60">Company No. 13245678</p>
-          <p className="text-white/60">71-75 Shelton Street, Covent Garden, London, WC2H 9JQ</p>
+          <p className="text-white/60">NORTHEDGE GROUP LTD • Company number 16579252</p>
           <p className="text-white/60">Support: support@northedgegroup.co.uk</p>
         </div>
         <div>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -19,10 +19,7 @@ export default function Header() {
         <div className="flex items-center gap-3">
           <Link to="/" className="flex items-center gap-3">
             <img src="/logo.png" alt="Royale Raffles" className="h-10 w-10 rounded-lg object-contain border border-white/10" />
-            <div className="text-2xl font-extrabold tracking-tight leading-tight">
-              <span className="text-claret">Royale</span>
-              <span className="text-blue-light">Raffles</span>
-            </div>
+            <span className="sr-only">Royale Raffles</span>
           </Link>
           <span className="hidden sm:inline-flex items-center px-3 py-1 rounded-full border border-blue-light/50 text-xs text-blue-light/90 bg-blue-light/10">
             Test Mode

--- a/src/data/raffles.js
+++ b/src/data/raffles.js
@@ -5,7 +5,7 @@ export default function seed() {
   return [
     {
       id: 1,
-      title: "Example Prize: iPhone 15 Pro (256GB)",
+      title: "iPhone 15 Pro (256GB)",
       image: "https://images.unsplash.com/photo-1510557880182-3d4d3cba35a5?q=80&w=1200&auto=format&fit=crop",
       description: "Flagship Apple smartphone with the A17 Pro chip, 6.1-inch Super Retina XDR display and pro camera system.",
       dioramaUrl: "/dioramas/sample.json",
@@ -25,7 +25,7 @@ export default function seed() {
     },
     {
       id: 2,
-      title: "Example Prize: PlayStation 5 Slim Bundle",
+      title: "PlayStation 5 Slim Bundle",
       image: "https://images.unsplash.com/photo-1606813907291-76b1b83d9a4c?q=80&w=1200&auto=format&fit=crop",
       description: "Latest generation PlayStation 5 Slim with DualSense controller and digital download of a blockbuster title.",
       value: 479,
@@ -44,7 +44,7 @@ export default function seed() {
     },
     {
       id: 3,
-      title: "Example Prize: MacBook Air 13\" (M3)",
+      title: "MacBook Air 13\" (M3)",
       image: "https://images.unsplash.com/photo-1517336714731-489689fd1ca8?q=80&w=1200&auto=format&fit=crop",
       description: "Lightweight MacBook Air with the M3 chip, 8GB unified memory and 256GB SSD — perfect for work or study.",
       value: 1299,
@@ -63,7 +63,7 @@ export default function seed() {
     },
     {
       id: 4,
-      title: "Example Prize: Nintendo Switch OLED",
+      title: "Nintendo Switch OLED",
       image: "https://images.unsplash.com/photo-1605901309584-818e25960a81?q=80&w=1200&auto=format&fit=crop",
       description: "Versatile Nintendo Switch OLED console with 64GB storage and neon red/blue Joy-Con controllers.",
       value: 309,
@@ -82,7 +82,7 @@ export default function seed() {
     },
     {
       id: 5,
-      title: "Example Prize: Dyson V15 Detect Absolute",
+      title: "Dyson V15 Detect Absolute",
       image: "https://images.unsplash.com/photo-1610276198568-eb6d0ff53e48?q=80&w=1200&auto=format&fit=crop",
       description: "Top-of-the-range Dyson cordless vacuum with laser dust detection and smart LCD reporting.",
       value: 629,

--- a/src/pages/HowItWorks.jsx
+++ b/src/pages/HowItWorks.jsx
@@ -13,9 +13,9 @@ export default function HowItWorks() {
       </header>
 
       <section className="glass rounded-2xl p-6 space-y-4">
-        <h2 className="text-2xl font-semibold">1. Browse Example Prizes</h2>
+        <h2 className="text-2xl font-semibold">1. Browse Prizes</h2>
         <p className="text-white/70 text-sm">
-          Explore our curated list of example prizes on the <Link to="/raffles" className="text-blue-light underline">Competitions page</Link>.
+          Explore our curated list of prizes on the <Link to="/raffles" className="text-blue-light underline">Competitions page</Link>.
           Each listing shows the total prize value in pounds sterling, ticket price, closing time and the number of tickets available.
           Customers can purchase entries instantly or claim one free entry by completing the postal route detailed on every prize page.
         </p>
@@ -25,7 +25,7 @@ export default function HowItWorks() {
         <h2 className="text-2xl font-semibold">2. How Raffles Are Drawn</h2>
         <ul className="list-disc list-inside text-white/70 text-sm space-y-2">
           <li>When the countdown ends or all tickets sell out, entries are locked and exported for the draw.</li>
-          <li>An independently verified random number generator selects the winning ticket.</li>
+          <li>The winning ticket is selected via the RANDOM.ORG verified draw service.</li>
           <li>Our compliance team double-checks eligibility (18+ UK resident, entry limits, free-entry submissions).</li>
           <li>The winner is contacted immediately and announced on the Winners Hub with their anonymised initials.</li>
         </ul>

--- a/src/pages/Privacy.jsx
+++ b/src/pages/Privacy.jsx
@@ -48,7 +48,7 @@ export default function Privacy() {
         <h2 className="text-2xl font-semibold">5. Contact</h2>
         <p className="text-white/70 text-sm">
           Data Protection Officer<br />
-          Northedge Group Ltd, 71-75 Shelton Street, Covent Garden, London, WC2H 9JQ<br />
+          Northedge Group Ltd Data Protection Team<br />
           Email: <a href="mailto:privacy@northedgegroup.co.uk" className="text-blue-light underline">privacy@northedgegroup.co.uk</a>
         </p>
       </section>

--- a/src/pages/RaffleDetails.jsx
+++ b/src/pages/RaffleDetails.jsx
@@ -102,9 +102,9 @@ export default function RaffleDetails() {
       <div className="glass rounded-2xl p-6 space-y-4">
         <div className="p-4 rounded-2xl border border-white/10 bg-black/30 text-sm text-white/80">
           <h2 className="text-lg font-semibold text-white">Free Entry Route</h2>
-          <p className="mt-2">To enter this raffle without purchasing tickets, send a first-class postal entry to: <b>Royale Raffles Free Entry, Northedge Group Ltd, 71-75 Shelton Street, Covent Garden, London, WC2H 9JQ</b>. Include your full name, email address, contact number, the raffle name, and confirmation that you are aged 18 or over. Postal entries must arrive before the published closing date.</p>
+          <p className="mt-2">To enter this raffle without purchasing tickets, send a first-class postal entry to the Royale Raffles free entry team. The full postal address will be confirmed before launch and can be requested by emailing <a href="mailto:support@northedgegroup.co.uk" className="text-blue-light underline">support@northedgegroup.co.uk</a>. Include your full name, email address, contact number, the raffle name, and confirmation that you are aged 18 or over. Postal entries must arrive before the published closing date.</p>
         </div>
-        <div className="text-xs text-white/60">Royale Raffles competitions are open to UK residents aged 18+. Winners are chosen at random using an independently verified draw system, and full results are published in the Winners Hub.</div>
+        <div className="text-xs text-white/60">Royale Raffles competitions are open to UK residents aged 18+. Winners are chosen at random using the RANDOM.ORG verified draw service, and full results are published in the Winners Hub.</div>
         <h2 className="text-xl font-semibold">{t('raffleDetails.participants')}</h2>
         <p className="text-white/70 text-sm">{t('raffleDetails.recentEntries')}</p>
         <div className="mt-4 grid sm:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/src/pages/Terms.jsx
+++ b/src/pages/Terms.jsx
@@ -4,7 +4,7 @@ export default function Terms() {
       <header className="glass rounded-3xl p-8 border border-white/10 space-y-3">
         <h1 className="text-3xl font-extrabold">Terms &amp; Conditions (Test Environment)</h1>
         <p className="text-white/70 text-sm">
-          Royale Raffles is a trading name of Northedge Group Ltd (Company No. 13245678). These terms outline how the
+          Royale Raffles is a trading name of Northedge Group Ltd (Company No. 16579252). These terms outline how the
           staging site operates ahead of final payment processor approval. The live service terms are materially the
           same, with the exception that all transactions here are simulated.
         </p>
@@ -23,7 +23,8 @@ export default function Terms() {
         <h2 className="text-2xl font-semibold">2. Free Postal Entry</h2>
         <p className="text-white/70 text-sm">
           To enter without purchase send your name, email, contact number, chosen raffle name and confirmation of your
-          eligibility to: <strong>Royale Raffles Free Entry, Northedge Group Ltd, 71-75 Shelton Street, Covent Garden, London, WC2H 9JQ</strong>.
+          eligibility to the Royale Raffles free entry team. The full postal address will be confirmed ahead of launch and is available on request from{' '}
+          <a href="mailto:support@northedgegroup.co.uk" className="text-blue-light underline">support@northedgegroup.co.uk</a>.
           Postal entries must be received before the raffle closes. Illegible or incomplete entries will be rejected.
         </p>
       </section>
@@ -39,7 +40,7 @@ export default function Terms() {
       <section className="glass rounded-2xl p-6 space-y-3">
         <h2 className="text-2xl font-semibold">4. Winner Selection</h2>
         <p className="text-white/70 text-sm">
-          Winners are chosen at random using a certified random number generator. Draw logs are retained for a minimum
+          Winners are chosen at random via the RANDOM.ORG verified draw service. Draw logs are retained for a minimum
           of three years and can be provided to regulators or payment partners on request. Northedge Group Ltd reserves
           the right to void entries that breach these terms or exceed the ticket purchase cap (50% of available tickets).
         </p>
@@ -57,7 +58,7 @@ export default function Terms() {
       <section className="glass rounded-2xl p-6 space-y-3">
         <h2 className="text-2xl font-semibold">6. Contact</h2>
         <p className="text-white/70 text-sm">
-          Northedge Group Ltd, 71-75 Shelton Street, Covent Garden, London, WC2H 9JQ.<br />
+          Northedge Group Ltd Compliance Team<br />
           Email: <a href="mailto:compliance@northedgegroup.co.uk" className="text-blue-light underline">compliance@northedgegroup.co.uk</a>
         </p>
       </section>


### PR DESCRIPTION
## Summary
- remove the Royale Raffles wordmark next to the header and footer logos and update the footer company copy with the latest registration number
- hide the on-site activity feed from the layout
- refresh compliance messaging to remove the example prize wording, mention RANDOM.ORG draws, update the company number, and temporarily omit the postal address

## Testing
- `npm run build` *(fails: npm is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc062bd82c8332a3ad859f1e397fc5