### PR TITLE
Connect raffle context to backend API

### DIFF
--- a/src/components/ShareModal.jsx
+++ b/src/components/ShareModal.jsx
@@ -4,7 +4,7 @@ export default function ShareModal({ shareText, url, onClose, onShared }) {
   const encodedUrl = encodeURIComponent(url)
   const encodedText = encodeURIComponent(shareText)
 
-  const handleShare = (platform) => {
+  const handleShare = async (platform) => {
     let shareUrl = ''
     switch (platform) {
       case 'twitter':
@@ -21,8 +21,11 @@ export default function ShareModal({ shareText, url, onClose, onShared }) {
     }
     if (shareUrl) {
       window.open(shareUrl, '_blank')
-      onShared()
-      onClose()
+      try {
+        await onShared?.()
+      } finally {
+        onClose()
+      }
     }
   }
 

--- a/src/pages/RaffleDetails.jsx
+++ b/src/pages/RaffleDetails.jsx
@@ -62,9 +62,7 @@ export default function RaffleDetails() {
 
   const shareText = `I joined this raffle for free on Royale Raffles! ${window.location.origin}/raffles/${r.id}`
   const shareUrl = window.location.origin + '/raffles/' + r.id
-  const handleShared = () => {
-    claimFreeTicket(r.id)
-  }
+  const handleShared = () => claimFreeTicket(r.id)
 
   return (
     <div className="py-8 space-y-6">


### PR DESCRIPTION
## Summary
- replace the raffle context's localStorage helpers with a reusable API client and refresh logic that pulls data from the backend
- switch purchase, free-entry, and admin mutations to call the new endpoints and sync context state from the server response
- update admin and modal components to await async operations so UI reflects shared raffle data consistently

## Testing
- npm run build *(fails: npm error 403 Forbidden - GET https://registry.npmjs.org/vite)*

------
https://chatgpt.com/codex/tasks/task_e_68cc17a141fc8332947c686b7e80c209